### PR TITLE
Breadcrumbs

### DIFF
--- a/packages/core/components/breadcrumbs/README.md
+++ b/packages/core/components/breadcrumbs/README.md
@@ -1,0 +1,29 @@
+### Overview
+The `Breadcrumbs` component is used to display a clickable path through the app
+hierarchy to the current screen.
+
+Currently the `path` gets passed in as an array of `{name, url}` objects representing
+the nodes of the path. Use the `highlightCurrent` prop to highlight the last node.
+
+Future versions should:
+- Integrate with React Router.
+- Accommodate images as optional node names (eg, app logo).
+
+```jsx
+const path = [
+  {
+    name: "Home",
+    url: "/"
+  },
+  {
+    name: "Places",
+    url: "/places/"
+  },
+  {
+    name: "Nearby",
+    url: "/places/nearby/"
+  }
+];
+
+<Breadcrumbs path={path} highlightCurrent></Breadcrumbs>
+```

--- a/packages/core/components/breadcrumbs/index.js
+++ b/packages/core/components/breadcrumbs/index.js
@@ -1,0 +1,78 @@
+/* @flow */
+
+import React from 'react';
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Link from "../link";
+
+const StyledBreadcrumbs = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  max-width: 100%;
+  padding: 1rem;
+  font-family: ${props => props.theme.fonts.sans};
+  font-size: ${props => props.theme.typeSystem.xs};
+
+  > * + * {
+    margin-left: .8rem;
+  }
+
+  > :last-child {
+    color: ${props => props.highlightCurrent ? props.theme.colors.grayDark1 : null};
+  }
+`;
+
+const BreadcrumbItem = Link.extend`
+  border: 0;
+  color: ${props =>  props.theme.colors.grayBase3};
+  font-size: ${props => props.theme.typeSystem.xs};
+  text-decoration: none;
+
+  &:hover {
+    color: ${props => props.theme.colors.primary};
+    text-decoration: underline;
+  }
+`;
+
+const Separator = styled.span`
+  color: ${props =>  props.theme.colors.grayLight2};
+
+  ::before {
+    content: "${props => props.theme.entities.breadcrumb}";
+  }
+`;
+
+const Breadcrumbs = props => {
+  return (
+    <StyledBreadcrumbs highlightCurrent={props.highlightCurrent}>
+      {props.path.map(({name, url}, idx) =>
+        <React.Fragment key={url}>
+          {idx > 0 && <Separator />}
+          <BreadcrumbItem href={url}>{name}</BreadcrumbItem>
+        </React.Fragment>
+      )}
+    </StyledBreadcrumbs>
+  );
+}
+
+Breadcrumbs.defaultProps = {
+  path: [],
+  highlightCurrent: false
+};
+
+Breadcrumbs.propTypes = {
+  /**
+   * Array of objects describing the breadcrumb path.
+   */
+  path: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  })).isRequired,
+  /**
+   * Highlight last breadcrumb item, to represent current screen.
+   */
+  highlightCurrent: PropTypes.bool
+};
+
+/** @component */
+export default Breadcrumbs;

--- a/packages/core/defaultTheme.js
+++ b/packages/core/defaultTheme.js
@@ -69,10 +69,15 @@ const buttonsStyles = {
   DEFAULT: "default"
 };
 
+const entities = {
+  breadcrumb: "▸"
+};
+
 export const theme = {
   colors,
   fonts,
   radius,
   typeSystem,
-  buttonsStyles
+  buttonsStyles,
+  entities
 };

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -5,6 +5,7 @@ export { default as Heading } from "./components/heading";
 export { default as PlainProgressBar } from "./components/plainProgressBar";
 export { default as ProgressBar } from "./components/progressBar";
 export { default as Tag } from "./components/tag";
+export { default as Breadcrumbs } from "./components/breadcrumbs";
 
 /* Theme related constants and methods */
 export * from "./defaultTheme";


### PR DESCRIPTION
Add a preliminary version of the Breadcrumbs component.

The `path` gets passed in as an array of `{name, url}` objects representing the nodes of the path. 

Use the `highlightCurrent` prop to optionally highlight the last node.

 Future versions should:
- Integrate with React Router.
- Accommodate images as optional node names (eg, app logo).
