### PR TITLE
fixes a breaking error in the start script

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 ./scripts/build && \
-./scripts/bootstrap && \
+lerna bootstrap && \
 NODE_ENV=development ./node_modules/react-styleguidist/bin/styleguidist.js server


### PR DESCRIPTION
We don't have a `./scripts/bootstrap`, so I replaced the line to directly run `lerna bootstrap`