### PR TITLE
Updated Link component to reflect true styling

### DIFF
--- a/packages/core/components/link/README.md
+++ b/packages/core/components/link/README.md
@@ -1,9 +1,11 @@
-### Usage
+Use the `<Link />` component to set the HTML `<a>` element (or anchor element) to create a hyperlink.
+
+_Accepts all `<a>` attributes_
 
 ```jsx
 <div>
-    <Link href="#" className="cool">This is a link</Link>
-
-    <Link href="#" className="cool" primary>This is a link</Link>
+  <Link href="#" autoFocus="true">
+    This is a link
+  </Link>
 </div>
 ```

--- a/packages/core/components/link/index.js
+++ b/packages/core/components/link/index.js
@@ -1,23 +1,33 @@
 /* @flow */
 
+import React from "react";
+import PropTypes from "prop-types";
+import { darken, rgba, shade } from "polished";
 import styled, { css } from "styled-components";
 
 const Link = styled.a`
-  border: 1px solid #ddd;
-  border-color: ${props => props.theme.colors.warning};
-  font-family: ${props => props.theme.fonts.sans};
+  text-decoration: none;
+  font-weight: 600;
+  color: ${props => props.theme.colors.primary};
   font-size: ${props => props.theme.typeSystem.base};
-  font-weight: ;
-  text-decoration: underline;
+  font-family: ${props => props.theme.fonts.sans};
 
-  ${props =>
-    props.primary &&
-    css`
-      background: ${props => props.theme.colors.primary};
-      border-color: ${props => props.theme.colors.primary};
-      color: #fff;
-    `};
+  &:hover {
+    text-decoration: underline;
+    color: ${props => darken(0.2, props.theme.colors.primary)};
+  }
 `;
+
+Link.defaultProps = {
+  href: "#"
+};
+
+Link.propTypes = {
+  /**
+   * Enforcing best practices by defining a default href
+   */
+  href: PropTypes.string.isRequired
+};
 
 /** @component */
 export default Link;

--- a/packages/core/components/link/index.js
+++ b/packages/core/components/link/index.js
@@ -8,13 +8,13 @@ import styled, { css } from "styled-components";
 const Link = styled.a`
   text-decoration: none;
   font-weight: 600;
-  color: ${props => props.theme.colors.primary};
+  color: ${props => props.theme.linkStyles.color};
   font-size: ${props => props.theme.typeSystem.base};
   font-family: ${props => props.theme.fonts.sans};
 
   &:hover {
     text-decoration: underline;
-    color: ${props => darken(0.2, props.theme.colors.primary)};
+    color: ${props => darken(0.2, props.theme.linkStyles.color)};
   }
 `;
 

--- a/packages/core/defaultTheme.js
+++ b/packages/core/defaultTheme.js
@@ -48,8 +48,8 @@ const fonts = {
 const typeSystem = {
   xs: "1rem",
   sm: "1.2rem",
-  base: "1.4rem",
-  med: "1.6rem",
+  base: "1.5rem",
+  med: "1.8rem",
   lg: "2rem",
   xl: "2.4rem",
   xxl: "3.6rem",

--- a/packages/core/defaultTheme.js
+++ b/packages/core/defaultTheme.js
@@ -69,6 +69,10 @@ const buttonsStyles = {
   DEFAULT: "default"
 };
 
+const linkStyles = {
+  color: "#738FFC"
+};
+
 const entities = {
   breadcrumb: "▸"
 };
@@ -79,5 +83,6 @@ export const theme = {
   radius,
   typeSystem,
   buttonsStyles,
+  linkStyles,
   entities
 };


### PR DESCRIPTION
Nothing fancy here. Simple styling for default links. I've opted to define a default declaration on the href attribute to prevent incorrect usage of `<a>`

<img width="765" alt="screen shot 2018-08-15 at 3 18 13 pm" src="https://user-images.githubusercontent.com/1928955/44168210-756aa380-a09e-11e8-8685-6e87b57512b6.png">
