### PR TITLE
Grouper component

### DIFF
--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -11,7 +11,7 @@ const baseStyles = css`
   outline: 0;
   border: 1px solid;
   padding: 1rem 2rem;
-  border-radius: ${props => props.theme.radius.base};
+  border-radius: ${props => props.theme.radii.base};
   font-weight: 600;
   line-height: 1.1;
   text-align: center;
@@ -89,7 +89,7 @@ function buttonStates(bgColor, textColor, ghostTextColor) {
       border: 1px solid ${darken(0.15, bgColor)};
       color: ${ghostTextColor};
     `}
-  
+
   ${props =>
     props.block &&
     css`

--- a/packages/core/components/card/index.js
+++ b/packages/core/components/card/index.js
@@ -10,7 +10,7 @@ const StyledCard = styled.div`
   background: ${props => props.theme.colors.white};
   box-shadow: 0 5px 10px -4px rgba(67, 83, 153, 0.2);
   border: 2px solid ${props => props.theme.colors.grayLight3};
-  border-radius: ${props => props.theme.radius.large};
+  border-radius: ${props => props.theme.radii.large};
   padding: 0;
 
   ${props =>

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -1,13 +1,39 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import {} from "styled-system";
+import { space } from "styled-system";
 
-const Grouper = styled.div`
+const StyledGrouper = styled.div`
+  ${space}
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-start;
   align-items: stretch;
+
+  > * {
+    border-radius: 0;
+  }
+
+  > :first-child {
+      border-radius: 10px 0 0 10px;
+  }
+
+  > :last-child {
+      border-radius: 0 10px 10px 0;
+  }
 `;
+
+const Grouper = props => {
+  return (
+    <Grouper {...props}>
+      {props.children}
+    </Grouper>
+  );
+};
+
+Grouper.propTypes = {
+  ...space.PropTypes,
+  // borderRadius: PropTypes.oneOf(Object.values())
+};
 
 export default Grouper;

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -1,39 +1,61 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { space } from "styled-system";
+import { space, themeGet } from "styled-system";
 
 const StyledGrouper = styled.div`
   ${space}
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-start;
-  align-items: stretch;
+  align-items: ${props => props.alignItems};
 
+  > * + * {
+    margin-left: ${props => props.gutter};
+  }
+`;
+
+const CompactGrouper = styled(StyledGrouper).attrs({
+  radius: props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)
+})`
   > * {
-    border-radius: 0;
+    border-radius: 0 !important;
   }
 
   > :first-child {
-      border-radius: 10px 0 0 10px;
+    border-top-left-radius: ${props => props.radius} !important;
+    border-bottom-left-radius: ${props => props.radius} !important;
   }
 
   > :last-child {
-      border-radius: 0 10px 10px 0;
+    border-top-right-radius: ${props => props.radius} !important;
+    border-bottom-right-radius: ${props => props.radius} !important;
   }
 `;
 
 const Grouper = props => {
-  return (
-    <Grouper {...props}>
+  return props.gutter === 0 ? (
+    <CompactGrouper {...props}>
       {props.children}
-    </Grouper>
+    </CompactGrouper>
+  ) : (
+    <StyledGrouper {...props}>
+      {props.children}
+    </StyledGrouper>
   );
 };
 
 Grouper.propTypes = {
   ...space.PropTypes,
-  // borderRadius: PropTypes.oneOf(Object.values())
+  borderRadius: PropTypes.string,
+  gutter: PropTypes.string,
+  alignItems: PropTypes.string
+};
+
+Grouper.defaultProps = {
+  borderRadius: 0,
+  gutter: 0,
+  alignItems: "stretch"
 };
 
 export default Grouper;

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -4,11 +4,15 @@ import styled from "styled-components";
 import { space, themeGet } from "styled-system";
 
 const StyledGrouper = styled.div`
-  ${space}
+  ${space};
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-start;
   align-items: ${props => props.alignItems};
+
+  > *:focus {
+    z-index: 1;
+  }
 
   > * + * {
     margin-left: ${props => props.gutter};
@@ -20,6 +24,10 @@ const CompactGrouper = styled(StyledGrouper).attrs({
 })`
   > * {
     border-radius: 0 !important;
+  }
+
+  > * + * {
+    border-left: none;
   }
 
   > :first-child {
@@ -34,26 +42,22 @@ const CompactGrouper = styled(StyledGrouper).attrs({
 `;
 
 const Grouper = props => {
-  return props.gutter === 0 ? (
-    <CompactGrouper {...props}>
-      {props.children}
-    </CompactGrouper>
+  return props.gutter == 0 ? (
+    <CompactGrouper {...props}>{props.children}</CompactGrouper>
   ) : (
-    <StyledGrouper {...props}>
-      {props.children}
-    </StyledGrouper>
+    <StyledGrouper {...props}>{props.children}</StyledGrouper>
   );
 };
 
 Grouper.propTypes = {
   ...space.PropTypes,
-  borderRadius: PropTypes.string,
-  gutter: PropTypes.string,
+  borderRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  gutter: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   alignItems: PropTypes.string
 };
 
 Grouper.defaultProps = {
-  borderRadius: 0,
+  borderRadius: "base",
   gutter: 0,
   alignItems: "stretch"
 };

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -1,0 +1,13 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import {} from "styled-system";
+
+const Grouper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  align-items: stretch;
+`;
+
+export default Grouper;

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -1,0 +1,11 @@
+---
+name: Grouper
+menu: Components
+route: /components/grouper
+---
+
+import { Playground, PropsTable } from 'docz'
+import Grouper from './'
+
+<Playground>
+</Playground>

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -6,8 +6,54 @@ route: /components/grouper
 
 import { Playground, PropsTable } from 'docz'
 import Grouper from './'
+import Button from '../button'
 
 # Grouper
 
+## Basic usage
+
 <Playground>
+  <Grouper>
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
 </Playground>
+
+## Radius
+
+<Playground>
+  <Grouper borderRadius="large">
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+</Playground>
+
+## Form
+
+<Playground>
+  <Grouper borderRadius="base">
+    <input type="text" />
+    <Button>Go</Button>
+  </Grouper>
+</Playground>
+
+## Gutter
+
+<Playground>
+  <Grouper gutter="1.6rem">
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+</Playground>
+
+
+### PropTypes
+| Prop | Type | Required | Description |
+|:-----|:-----|:---------|:------------|
+| borderRadius | string | false | use `theme.radii`. applies to outer corners of first & last children. ignored if `gutter` provided. |
+| gutter | string | false | gap between children |
+| alignItems | string | false | default is "stretch" |
+| ${space} | string | false | see [styled-system SPACE](https://jxnblk.com/styled-system/#margin--padding) |

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -7,5 +7,7 @@ route: /components/grouper
 import { Playground, PropsTable } from 'docz'
 import Grouper from './'
 
+# Grouper
+
 <Playground>
 </Playground>

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -20,10 +20,10 @@ import Button from '../button'
   </Grouper>
 </Playground>
 
-## Radius
+## Radius overrides
 
 <Playground>
-  <Grouper borderRadius="large">
+  <Grouper borderRadius="0">
     <Button>Hello</Button>
     <Button>Crazy</Button>
     <Button>World</Button>

--- a/packages/core/components/image/index.js
+++ b/packages/core/components/image/index.js
@@ -13,7 +13,7 @@ const Image = styled.img`
   ${props =>
     props.rounded &&
     css`
-      border-radius: ${props => props.theme.radius.base};
+      border-radius: ${props => props.theme.radii.base};
     `};
 
   ${props =>

--- a/packages/core/defaultTheme.js
+++ b/packages/core/defaultTheme.js
@@ -56,7 +56,7 @@ const typeSystem = {
   xxxxl: "3.4rem"
 };
 
-const radius = {
+const radii = {
   small: "3px",
   base: "5px",
   large: "10px"
@@ -79,7 +79,7 @@ const entities = {
 export const theme = {
   colors,
   fonts,
-  radius,
+  radii,
   typeSystem,
   buttonsStyles,
   linkStyles,

--- a/packages/core/index.components.js
+++ b/packages/core/index.components.js
@@ -4,6 +4,7 @@ export { default as Button } from "./components/button";
 export { default as ButtonGroup } from "./components/buttonGroup";
 export { default as Card } from "./components/card";
 export { default as Divider } from "./components/divider";
+export { default as Grouper } from "./components/grouper";
 export { default as Header } from "./components/header";
 export { default as Image } from "./components/image";
 export { default as Link } from "./components/link";


### PR DESCRIPTION
## Overview

Add the Grouper component.

By default, children are lined up against each other and all corners are forced to `border-radius: 0`.

Border radius of the outer corners of the first & last children can be changed via the `borderRadius` prop, which expects a key from `theme.radii` but will accept any valid CSS `border-radius` value.

Children can be spread apart via the `gutter` prop, which accepts a valid CSS `margin` value. When a non-zero `gutter` is supplied, `borderRadius` is ignored, such that the children determine their own border radii.

The `alignItems` prop (default: `stretch`) can be used to adjust childrens' vertical alignment.


### Checklist

- [x] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


### Demo

![image](https://user-images.githubusercontent.com/128699/48287069-9fc9c400-e435-11e8-8317-32e28b3230f5.png)


Closes #89 
