### PR TITLE
Fix docz build script to include reset.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
+- Build script for docz documentation site and it now properly copies the reset.css file into the dist folder
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
-- Build script for docz documentation site and it now properly copies the reset.css file into the dist folder
+- Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [\#100](https://github.com/raster-foundry/blasterjs/pull/111)
 
 ### Security
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="{{ description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" type="text/css" href="{{ publicUrl }}/reset.css">
+  <link rel="stylesheet" href="{{ publicUrl }}/reset.css">
   <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500,600,700|Source+Code+Pro:400,600" rel="stylesheet">
   <title>{{ title }}</title>
   {{ head }}

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="{{ description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="{{ publicUrl }}/reset.css">
+  <link rel="stylesheet" type="text/css" href="{{ publicUrl }}/reset.css">
   <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500,600,700|Source+Code+Pro:400,600" rel="stylesheet">
   <title>{{ title }}</title>
   {{ head }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "build": "./scripts/build",
-    "build-docz": "docz build",
+    "build-docz": "./scripts/build-docz",
     "clean": "./scripts/clean",
     "docz": "docz dev",
     "release": "./scripts/release",

--- a/scripts/build-docz
+++ b/scripts/build-docz
@@ -1,0 +1,3 @@
+mkdir -p ./.docz/public && \
+cp ./packages/core/reset.css ./.docz/public/reset.css && \
+docz build


### PR DESCRIPTION
## Overview

Adjusts the build script to include the reset.css file

### Checklist

- ~[ ] Relevant documentation pages have been created or updated~
- [x] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible

Closes #110 
