### PR TITLE
Add Box component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `Divider` component added to the core package [#94](https://github.com/raster-foundry/blasterjs/pull/94)
 - `Icon` component added to the core package [#103](https://github.com/raster-foundry/blasterjs/pull/103)
+- `Box` component added to the core package [#112](https://github.com/raster-foundry/blasterjs/pull/112)
 
 ### Changed
 - Changed theme file `radius` to `radii` (breaking change for custom themes)

--- a/packages/core/components/box/index.js
+++ b/packages/core/components/box/index.js
@@ -1,0 +1,93 @@
+import React from "react";
+import styled from "styled-components";
+import * as styledSystem from "styled-system"
+
+const StyledBox = styled.div`
+  ${styledSystem.display}
+  ${styledSystem.space}
+  ${styledSystem.width}
+  ${styledSystem.maxWidth}
+  ${styledSystem.minWidth}
+  ${styledSystem.height}
+  ${styledSystem.maxHeight}
+  ${styledSystem.minHeight}
+  ${styledSystem.ratio}
+  ${styledSystem.verticalAlign}
+  ${styledSystem.alignItems}
+  ${styledSystem.justifyContent}
+  ${styledSystem.flexWrap}
+  ${styledSystem.flexDirection}
+  ${styledSystem.flex}
+  ${styledSystem.alignContent}
+  ${styledSystem.justifyItems}
+  ${styledSystem.justifySelf}
+  ${styledSystem.alignSelf}
+  ${styledSystem.order}
+  ${styledSystem.flexBasis}
+  ${styledSystem.gridGap}
+  ${styledSystem.gridRowGap}
+  ${styledSystem.gridColumnGap}
+  ${styledSystem.gridColumn}
+  ${styledSystem.gridRow}
+  ${styledSystem.gridArea}
+  ${styledSystem.gridAutoFlow}
+  ${styledSystem.gridAutoRows}
+  ${styledSystem.gridAutoColumns}
+  ${styledSystem.gridTemplateRows}
+  ${styledSystem.gridTemplateColumns}
+  ${styledSystem.gridTemplateAreas}
+  ${styledSystem.overflow}
+  ${styledSystem.position}
+  ${styledSystem.zIndex}
+  ${styledSystem.top}
+  ${styledSystem.right}
+  ${styledSystem.bottom}
+  ${styledSystem.left}
+`;
+
+const Box = props => <StyledBox {...props} />;
+
+Box.propTypes = {
+  ...styledSystem.display.propTypes,
+  ...styledSystem.space.propTypes,
+  ...styledSystem.width.propTypes,
+  ...styledSystem.maxWidth.propTypes,
+  ...styledSystem.minWidth.propTypes,
+  ...styledSystem.height.propTypes,
+  ...styledSystem.maxHeight.propTypes,
+  ...styledSystem.minHeight.propTypes,
+  ...styledSystem.ratio.propTypes,
+  ...styledSystem.verticalAlign.propTypes,
+  ...styledSystem.alignItems.propTypes,
+  ...styledSystem.justifyContent.propTypes,
+  ...styledSystem.flexWrap.propTypes,
+  ...styledSystem.flexDirection.propTypes,
+  ...styledSystem.flex.propTypes,
+  ...styledSystem.alignContent.propTypes,
+  ...styledSystem.justifyItems.propTypes,
+  ...styledSystem.justifySelf.propTypes,
+  ...styledSystem.alignSelf.propTypes,
+  ...styledSystem.order.propTypes,
+  ...styledSystem.flexBasis.propTypes,
+  ...styledSystem.gridGap.propTypes,
+  ...styledSystem.gridRowGap.propTypes,
+  ...styledSystem.gridColumnGap.propTypes,
+  ...styledSystem.gridColumn.propTypes,
+  ...styledSystem.gridRow.propTypes,
+  ...styledSystem.gridArea.propTypes,
+  ...styledSystem.gridAutoFlow.propTypes,
+  ...styledSystem.gridAutoRows.propTypes,
+  ...styledSystem.gridAutoColumns.propTypes,
+  ...styledSystem.gridTemplateRows.propTypes,
+  ...styledSystem.gridTemplateColumns.propTypes,
+  ...styledSystem.gridTemplateAreas.propTypes,
+  ...styledSystem.overflow.propTypes,
+  ...styledSystem.position.propTypes,
+  ...styledSystem.zIndex.propTypes,
+  ...styledSystem.top.propTypes,
+  ...styledSystem.right.propTypes,
+  ...styledSystem.bottom.propTypes,
+  ...styledSystem.left.propTypes
+};
+
+export default Box;

--- a/packages/core/components/box/index.mdx
+++ b/packages/core/components/box/index.mdx
@@ -1,0 +1,68 @@
+---
+name: Box
+menu: Components
+route: /components/box
+---
+
+import { Playground, PropsTable } from 'docz'
+import Box from './'
+
+# Box
+
+Generic container for handling layout.
+
+<Playground>
+    <Box mt={4} px={10} width="10.5em" overflow="hidden">Myspoonistoobig</Box>
+    <Box p={6} display="flex" flexDirection="row" alignItems="center" justifyContent="space-between">
+        <span>I</span>
+        <span>am</span>
+        <span>a</span>
+        <span>banana</span>
+    </Box>
+</Playground>
+
+
+
+### PropTypes
+| Prop | Type | Required | Description |
+|:-----|:-----|:---------|:------------|
+| ${display} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${space} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${width} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${maxWidth} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${minWidth} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${height} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${maxHeight} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${minHeight} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${ratio} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${verticalAlign} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${alignItems} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${justifyContent} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${flexWrap} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${flexDirection} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${flex} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${alignContent} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${justifyItems} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${justifySelf} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${alignSelf} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${order} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${flexBasis} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridGap} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridRowGap} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridColumnGap} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridColumn} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridRow} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridArea} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridAutoFlow} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridAutoRows} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridAutoColumns} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridTemplateRows} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridTemplateColumns} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${gridTemplateAreas} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${overflow} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${position} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${zIndex} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${top} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${right} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${bottom} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |
+| ${left} | number or string | false | see [styled-system](https://jxnblk.com/styled-system/) |

--- a/packages/core/index.components.js
+++ b/packages/core/index.components.js
@@ -1,4 +1,5 @@
 export { default as Badge } from "./components/badge";
+export { default as Box } from "./components/box";
 export { default as Brand } from "./components/brand";
 export { default as Breadcrumbs } from "./components/breadcrumbs";
 export { default as Button } from "./components/button";


### PR DESCRIPTION
## Overview

Introduce the Box component. 

We considered two existing approaches to this component:

- **Kitchen Sink**. eg, [Pulse](https://github.com/heartbeatua/Pulse-Boilerplate/blob/master/src/components/atoms/Box/Box.js). Create an omnibus component that includes virtually every styled-system function.

- **Family of Layout Components**. eg, [Rebass](https://rebassjs.org/Box). Create a set of layout components, one for each layout model. `Box` would encapsulate styled-system's flow layout functions. `Flex` would extend `Box`, set `display: flex`, and add flex props. `Grid` would do the same for grid layout.

I opted to thread the needle with a **hybrid** approach. Our `Box` component is single component that supports all 3 layouts (flow, flex, grid) but strictly limits itself to layout only (so strictly, in fact, that unlike Rebass it even excludes `fontSize` and `color`).

### Included styled-system functions
margin & padding: `space`
layout: `display`, `verticalAlign`, all flex props, all grid props
dimensions: `width`, `height`, `{min, max}{Width, Height}`, `ratio`
containment: `overflow`
position: `position`, `zIndex`, `top`, `right`, `bottom`, `left`

### Excluded styled-system functions
type: `fontFamily`, `textAlign`, `lineHeight`, `fontWeight`, `fontStyle`, `letterSpacing`, `textStyle`
visual: `background*`, `border*`, `boxShadow`, `opacity`, `colorStyle`


### Checklist

- [x] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


Are there any of the following in this PR?

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`

### Demo

![image](https://user-images.githubusercontent.com/128699/49234470-1834fc80-f3c6-11e8-894e-817c4c23ffed.png)


Closes #87 
