### PR TITLE
New Box prop: tag

### DIFF
--- a/packages/core/components/a/index.js
+++ b/packages/core/components/a/index.js
@@ -2,11 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { display, space, color, fontSize, themeGet } from "styled-system";
+import Text from "../text";
 
-const StyledA = styled.a`
-  ${display}
-  ${space}
-  ${color}
+const StyledA = styled(Text)`
   text-decoration: none;
   font-weight: 600;
 
@@ -19,10 +17,7 @@ const StyledA = styled.a`
 const A = props => <StyledA {...props} />;
 
 A.propTypes = {
-  ...display.propTypes,
-  ...space.propTypes,
-  ...color.propTypes,
-  ...fontSize.propTypes,
+  ...Text.propTypes,
   href: PropTypes.string.isRequired,
   active: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -30,6 +25,7 @@ A.propTypes = {
 };
 
 A.defaultProps = {
+  tag: "a",
   href: "#",
   color: "link",
   colorHover: "linkHover"

--- a/packages/core/components/a/index.js
+++ b/packages/core/components/a/index.js
@@ -6,7 +6,6 @@ import Text from "../text";
 
 const StyledA = styled(Text)`
   text-decoration: none;
-  font-weight: 600;
 
   &:hover {
     text-decoration: underline;
@@ -28,7 +27,8 @@ A.defaultProps = {
   tag: "a",
   href: "#",
   color: "link",
-  colorHover: "linkHover"
+  colorHover: "linkHover",
+  fontWeight: 600
 };
 
 export default A;

--- a/packages/core/components/a/index.mdx
+++ b/packages/core/components/a/index.mdx
@@ -18,7 +18,7 @@ Accepts standard html `<a>` attributes
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| Box props | | | | see [Box](/components/box) |
+| Text props | | | | see [Text](/components/text) |
 | href | bool | yes | `#` | |
 | active | bool | no | | *not implemented yet* |
 | disabled | bool | no | | *not implemented yet* |

--- a/packages/core/components/a/index.mdx
+++ b/packages/core/components/a/index.mdx
@@ -24,4 +24,3 @@ Accepts standard html `<a>` attributes
 | disabled | bool | no | | *not implemented yet* |
 | color | string | no | `link` | |
 | colorHover | string | no | `linkHover` | *expand into a `colors` object with colors for all states?* |
-| fontSize | number or string | no | | see [styled-system FONTSIZE](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#fontsize) |

--- a/packages/core/components/badge/index.js
+++ b/packages/core/components/badge/index.js
@@ -1,30 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { color, fontSize, borderRadius } from "styled-system";
-import Box from "../box";
+import { borderRadius } from "styled-system";
+import Text from "../text";
 
-const StyledBadge = styled(Box)`
+const StyledBadge = styled(Text)`
   display: inline-block;
   line-height: 1;
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
-  ${color}
-  ${fontSize}
   ${borderRadius}
 `;
 
 const Badge = props => {
   return (
-    <StyledBadge {...props}>{props.children}</StyledBadge>
+    <StyledBadge {...props} />
   );
 };
 
 Badge.propTypes = {
-  ...Box.propTypes,
-  ...color.propTypes,
-  ...fontSize.propTypes,
+  ...Text.propTypes,
   ...borderRadius.propTypes
 };
 

--- a/packages/core/components/badge/index.mdx
+++ b/packages/core/components/badge/index.mdx
@@ -67,11 +67,7 @@ import { Shape } from "../../common/shape";
 ### Badge
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| Box props | | | | see [Box](/components/box) |
-| ${space} | number or string | no | | see [styled-system SPACE](https://jxnblk.com/styled-system/#margin--padding) |
-| color | string | no | `textBase` | see [styled-system COLOR](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#color) |
-| bg | string | no | `grayLightest` | see [styled-system COLOR](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#color) |
-| fontSize | number or string | no | `1` | see [styled-system FONTSIZE](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#fontsize) |
+| Text props | | | | see [Text](/components/text) |
 | borderRadius | number or string | no | `small` | see [styled-system BORDERRADIUS](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#borders) |
 
 ### Pill

--- a/packages/core/components/box/index.js
+++ b/packages/core/components/box/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import * as styledSystem from "styled-system";
 
@@ -45,9 +46,10 @@ const StyledBox = styled.div`
   ${styledSystem.left}
 `;
 
-const Box = props => <StyledBox {...props} />;
+const Box = ({tag, ...props}) => <StyledBox as={tag} {...props} />;
 
 Box.propTypes = {
+  tag: PropTypes.string,
   ...styledSystem.display.propTypes,
   ...styledSystem.space.propTypes,
   ...styledSystem.width.propTypes,
@@ -88,6 +90,10 @@ Box.propTypes = {
   ...styledSystem.right.propTypes,
   ...styledSystem.bottom.propTypes,
   ...styledSystem.left.propTypes
+};
+
+Box.defaultProps = {
+  tag: undefined
 };
 
 export default Box;

--- a/packages/core/components/box/index.mdx
+++ b/packages/core/components/box/index.mdx
@@ -26,6 +26,7 @@ Generic container for handling layout.
 ### PropTypes
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
+| tag | string | no | `div` | html tag to be rendered |
 | ${display} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
 | ${space} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
 | ${width} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |

--- a/packages/core/components/breadcrumbs/index.js
+++ b/packages/core/components/breadcrumbs/index.js
@@ -2,12 +2,11 @@ import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { fontSize, themeGet } from "styled-system";
-import Box from "../box";
+import Text from "../text";
 import A from "../a";
 import Icon from "../icon";
 
-const StyledBreadcrumbs = styled(Box)`
-  ${fontSize}
+const StyledBreadcrumbs = styled(Text)`
   display: flex;
   flex-flow: row wrap;
   max-width: 100%;
@@ -77,8 +76,7 @@ const Breadcrumbs = ({
 };
 
 Breadcrumbs.propTypes = {
-  ...Box.propTypes,
-  ...fontSize.propTypes,
+  ...Text.propTypes,
   highlightCurrent: PropTypes.bool,
   color: PropTypes.string,
   colorHover: PropTypes.string,

--- a/packages/core/components/breadcrumbs/index.mdx
+++ b/packages/core/components/breadcrumbs/index.mdx
@@ -35,7 +35,7 @@ Future versions should integrate with React Router.
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| Box props | | | | see [Box](/components/box) |
+| Text props | | | | see [Text](/components/text) |
 | path | array | yes | | `{name, url}` objects representing path nodes |
 | fontSize | string or number | no | `2` | |
 | highlightCurrent | bool | no | `false` | highlight last node in path |

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -2,7 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { darken, rgba } from "polished";
 import styled, { css } from "styled-components";
-import { space, borderRadius, themeGet } from "styled-system";
+import { borderRadius, themeGet } from "styled-system";
+import Text from "../text";
 import Icon from "../icon";
 import { Intent } from "../../common/intent";
 import { Appearance } from "../../common/appearance";
@@ -41,7 +42,7 @@ const ButtonLoading = styled.span`
   font-size: ${themeGet('fontSizes.1', 'inherit')};
 `;
 
-const StyledButton = styled.button`
+const StyledButton = styled(Text)`
   position: relative;
   cursor: pointer;
   display: inline-flex;
@@ -56,8 +57,6 @@ const StyledButton = styled.button`
   user-select: none;
   will-change: box-shadow, background-color;
   transition: 0.1s ease-in-out box-shadow, 0.1s ease-in-out background-color;
-
-  ${space}
   ${borderRadius}
 
   ${props => buttonStates(props)}
@@ -147,18 +146,17 @@ function buttonStates(props) {
   `;
 }
 
-const Button = props => {
-  const {
-    iconBefore,
-    iconAfter,
-    isLoading,
-    children,
-    ...otherProps
-  } = props;
+const Button = ({
+  iconBefore,
+  iconAfter,
+  isLoading,
+  children,
+  ...props
+}) => {
 
   return (
-    <StyledButton {...otherProps}>
-      <ButtonChildren {...props}>
+    <StyledButton {...props}>
+      <ButtonChildren iconBefore={iconBefore} iconAfter={iconAfter} isLoading={isLoading}>
         {iconBefore && <ButtonIcon name={iconBefore} mr={1} />}
         {children}
         {iconAfter && <ButtonIcon name={iconAfter} ml={1} />}
@@ -169,7 +167,7 @@ const Button = props => {
 };
 
 Button.propTypes = {
-  ...space.propTypes,
+  ...Text.propTypes,
   ...borderRadius.propTypes,
   intent: PropTypes.oneOf(Object.values(Intent)),
   appearance: PropTypes.oneOf(Object.values(Appearance)),
@@ -181,6 +179,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
+  tag: "button",
   pt: 1,
   pb: 1,
   pl: 1,

--- a/packages/core/components/button/index.mdx
+++ b/packages/core/components/button/index.mdx
@@ -81,7 +81,7 @@ import { Appearance } from "../../common/appearance";
 ### PropTypes
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| ${space} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
+| Text props | | | | see [Text](/components/text) |
 | borderRadius | number or string | no | `base` | |
 | intent | enum | no | `NONE` | see `common/intent` |
 | appearance | enum | no | `DEFAULT` | see `common/appearance` |

--- a/packages/core/components/callout/index.js
+++ b/packages/core/components/callout/index.js
@@ -24,7 +24,7 @@ const CalloutIcon = styled(Icon)`
   margin: 0 ${themeGet('space.2', '1.6rem')};
 `;
 
-const CalloutTitle = styled(Header).attrs({ as: "h4" })`
+const CalloutTitle = styled(Header).attrs({ tag: "h4" })`
   margin-bottom: ${themeGet('space.1', '0.8rem')};
   line-height: 1;
 `;

--- a/packages/core/components/callout/index.mdx
+++ b/packages/core/components/callout/index.mdx
@@ -74,7 +74,6 @@ import { Intent } from '../../common/intent'
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
 | Box props | | | | see [Box](/components/box) |
-| ${space} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
 | intent | enum | no | `NONE` | see `common/intent` |
 | icon | string or bool | no | | name of icon. overrides intent's default icon. |
 | iconSize | string | no | | |

--- a/packages/core/components/card/index.mdx
+++ b/packages/core/components/card/index.mdx
@@ -14,7 +14,7 @@ import A from '../a';
 
 <Playground>
   <Card density={Density.COMFORTABLE}>
-    <Header as="h2">Hello world</Header>
+    <Header tag="h2">Hello world</Header>
     <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Id magni repellendus illum quasi, officiis assumenda facere inventore accusamus maiores soluta, qui quibusdam et, dolorum tempora ab a unde porro eligendi!</p>
     <A href="#">Continue</A>
   </Card>

--- a/packages/core/components/divider/index.js
+++ b/packages/core/components/divider/index.js
@@ -1,19 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { space, themeGet } from "styled-system";
+import { themeGet } from "styled-system";
 import { Direction } from "../../common/direction";
+import Box from "../box";
 
-const HDivider = styled.hr`
-  ${space}
+const HDivider = styled(Box).attrs({
+  tag: 'hr'
+})`
   background-color: ${props => themeGet(`colors.${props.color}`, themeGet('colors.grayLight1'))};
   border: 0;
   width: ${props => props.width || "100%"};
   height: ${props => props.height || "1px"};
 `;
 
-const VDivider = styled.span`
-  ${space}
+const VDivider = styled(Box).attrs({
+  tag: 'span'
+})`
   display: inline-block;
   vertical-align: middle;
   background-color: ${props => themeGet(`colors.${props.color}`, themeGet('colors.grayLight1'))};
@@ -38,7 +41,7 @@ const Divider = props => {
 };
 
 Divider.propTypes = {
-  ...space.PropTypes,
+  ...Box.propTypes,
   direction: PropTypes.oneOf(Object.values(Direction)).isRequired,
   color: PropTypes.string,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/core/components/divider/index.mdx
+++ b/packages/core/components/divider/index.mdx
@@ -10,44 +10,31 @@ import { Direction } from "../../common/direction";
 
 # Divider
 
-## Vertical Divider with horizontal margin
+## Vertical Divider
 
 <Playground>
     Something on the left
-    <Divider direction={Direction.VERTICAL} mx={"0.8rem"} />
+    <Divider direction={Direction.VERTICAL} mx={1} />
+    Something in the middle
+    <Divider direction={Direction.VERTICAL} width="4px" height="4rem" mx={3} color="primary" />
     Something on the right
 </Playground>
 
-## Vertical Divider with margin, width, height, color
-
-<Playground>
-    Something on the left
-    <Divider direction={Direction.VERTICAL} width={"4px"} height={"4rem"} mx={"2.4rem"} color={"primary"} />
-    Something on the right
-</Playground>
-
-
-## Horizontal Divider with vertical margin
+## Horizontal Divider
 
 <Playground>
     Something on the top
-    <Divider direction={Direction.HORIZONTAL} my={"1.6rem"} />
-    Something on the bottom
-</Playground>
-
-## Horizontal Divider with margin, width, height, color
-
-<Playground>
-    Something on the top
-    <Divider direction={Direction.HORIZONTAL} width={"60%"} height={"4px"} ml={0} my={"4rem"} color={"secondary"} />
+    <Divider direction={Direction.HORIZONTAL} my={2} />
+    Something in the middle
+    <Divider direction={Direction.HORIZONTAL} width="60%" height="4px" ml={0} my={5} color="secondary" />
     Something on the bottom
 </Playground>
 
 ## PropTypes
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
+| Box props | | | | see [Box](/components/box) |
 | direction | enum | yes | | see `common/direction` |
 | color | string | no | | Theme color or valid css color value  |
 | width | string | no | | `2px` when vertical |
 | height | string | no | | `1px` when horizontal |
-| ${space} | string | no | | see [styled-system](https://jxnblk.com/styled-system/#margin--padding) |

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { space, themeGet } from "styled-system";
+import { themeGet } from "styled-system";
+import Box from "../box";
 
-const StyledGrouper = styled.div`
-  ${space}
+const StyledGrouper = styled(Box)`
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-start;
@@ -44,7 +44,7 @@ const Grouper = props => {
 };
 
 Grouper.propTypes = {
-  ...space.PropTypes,
+  ...Box.PropTypes,
   borderRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   gutter: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   alignItems: PropTypes.string

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -53,6 +53,7 @@ import Button from '../button'
 ### PropTypes
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
+| Box props | | | | see [Box](/components/box) |
 | borderRadius | string | no | `base` | outer corners of first & last children. ignored iff `gutter`. |
 | gutter | string | no | `0` | gap between children |
 | alignItems | string | no | `stretch` | |

--- a/packages/core/components/header/index.js
+++ b/packages/core/components/header/index.js
@@ -1,14 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
-import { space, color, fontFamily, lineHeight, textAlign, themeGet } from "styled-system";
+import { themeGet } from "styled-system";
+import Text from "../text";
 
-const Header = styled.h1`
-  ${space}
-  ${color}
-  ${lineHeight}
-  ${textAlign}
-  ${fontFamily}
+const Header = styled(Text)`
   font-weight: 700;
 
   ${props => {
@@ -19,7 +15,7 @@ const Header = styled.h1`
       h4: 4,
       h5: 3,
       h6: 2
-    }[props.as];
+    }[props.tag];
 
     return css`
       font-size: ${props => themeGet(`fontSizes.${size}`)};
@@ -28,15 +24,12 @@ const Header = styled.h1`
 `;
 
 Header.propTypes = {
-  ...space.propTypes,
-  ...color.propTypes,
-  ...textAlign.propTypes,
-  ...fontFamily.propTypes,
-  as: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+  ...Text.propTypes,
+  tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
 };
 
 Header.defaultProps = {
-  as: "h1",
+  tag: "h1",
   color: "textBase",
   fontFamily: "display",
   lineHeight: 2,

--- a/packages/core/components/header/index.mdx
+++ b/packages/core/components/header/index.mdx
@@ -11,12 +11,12 @@ import Header from './'
 
 <Playground>
   <Header children="Content defined with a prop" />
-  <Header as="h1">This is h1 (default)</Header>
-  <Header as="h2">This is h2</Header>
-  <Header as="h3">This is h3</Header>
-  <Header as="h4">This is h4</Header>
-  <Header as="h5">This is h5</Header>
-  <Header as="h6">This is h6</Header>
+  <Header tag="h1">This is h1 (default)</Header>
+  <Header tag="h2">This is h2</Header>
+  <Header tag="h3">This is h3</Header>
+  <Header tag="h4">This is h4</Header>
+  <Header tag="h5">This is h5</Header>
+  <Header tag="h6">This is h6</Header>
   <Header textAlign="center">This is a centered Header</Header>
 </Playground>
 
@@ -24,9 +24,7 @@ import Header from './'
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| as | string | no | `h1` | `[h1, h2, h3, h4, h5, h6]` |
+| Text props | | | | see [Text](/components/text) |
+| tag | string | no | `h1` | `[h1, h2, h3, h4, h5, h6]` |
 | color | string | no | `textBase` | |
 | lineHeight | number or string | no | `2` | |
-| textAlign | string | no | | |
-| fontFamily | string | no | `display` | should be a key in theme fonts |
-| ${space} | string | no | | see [styled-system](https://jxnblk.com/styled-system/#margin--padding) |

--- a/packages/core/components/icon/index.js
+++ b/packages/core/components/icon/index.js
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled, { withTheme } from "styled-components";
-import { color, size, space } from "styled-system";
+import { size } from "styled-system";
+import Text from "../text";
 
 /* helpful links
   SVG optimization
@@ -10,10 +11,8 @@ import { color, size, space } from "styled-system";
   - https://github.com/elrumordelaluz/svgson-next
   - https://github.com/Angelmmiguel/svgi
 */
-const StyledIcon = styled.svg`
-  ${color}
+const StyledIcon = styled(Text)`
   ${size}
-  ${space}
   vertical-align: middle;
 `;
 
@@ -34,13 +33,13 @@ const Icon = withTheme(props => {
 });
 
 Icon.propTypes = {
-  ...space.proptTypes,
-  ...color.propTypes,
+  ...Text.propTypes,
   ...size.propTypes,
   name: PropTypes.string.isRequired
 };
 
 Icon.defaultProps = {
+  tag: "svg",
   size: "1em",
   mt: "-2px",
   mb: 0,

--- a/packages/core/components/icon/index.mdx
+++ b/packages/core/components/icon/index.mdx
@@ -19,7 +19,6 @@ import Icon from "./";
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
+| Text props | | | | see [Text](/components/text) |
 | name | string | yes | | see `theme.icons` |
-| space | number or string | no | | see [styled-system](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space) |
 | size | string | no | | see [styled-system](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#layout) |
-| color | string | no | | see [styled-system](https://github.com/jxnblk/styled-system/blob/master/docs/api.md#color) |

--- a/packages/core/components/image/index.js
+++ b/packages/core/components/image/index.js
@@ -1,14 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { space, width, height, borderRadius } from "styled-system";
+import { width, height, borderRadius } from "styled-system";
 import { Shape } from "../../common/shape";
+import Box from "../box";
 
-const StyledImage = styled.img`
+const StyledImage = styled(Box)`
   display: inline-block;
   vertical-align: middle;
   max-width: 100%;
-  ${space}
   ${width}
   ${height}
   ${borderRadius}
@@ -36,7 +36,7 @@ const Image = ({borderRadius, shape, ...props}) => {
 };
 
 Image.propTypes = {
-  ...space.propTypes,
+  ...Box.propTypes,
   ...width.propTypes,
   ...height.propTypes,
   ...borderRadius.propTypes,
@@ -45,6 +45,7 @@ Image.propTypes = {
 };
 
 Image.defaultProps = {
+  tag: "img",
   width: "auto",
   height: "auto",
   shape: Shape.SQUARE,

--- a/packages/core/components/image/index.mdx
+++ b/packages/core/components/image/index.mdx
@@ -42,7 +42,7 @@ Accepts standard html `<img>` attributes
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| ${space} | number or string | no |  | see [styled-system](https://jxnblk.com/styled-system/) |
+| Box props | | | | see [Box](/components/box) |
 | src | url | yes | | |
 | width | string | no | `auto` | |
 | height | string | no | `auto` | |

--- a/packages/core/components/text/index.js
+++ b/packages/core/components/text/index.js
@@ -2,25 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import * as styledSystem from "styled-system";
+import Box from "../box";
 
-const Text = styled.p`
-    ${styledSystem.display}
-    ${styledSystem.space}
-    ${styledSystem.width}
-    ${styledSystem.maxWidth}
-    ${styledSystem.minWidth}
-    ${styledSystem.height}
-    ${styledSystem.maxHeight}
-    ${styledSystem.minHeight}
-    ${styledSystem.ratio}
-    ${styledSystem.verticalAlign}
-    ${styledSystem.overflow}
-    ${styledSystem.position}
-    ${styledSystem.zIndex}
-    ${styledSystem.top}
-    ${styledSystem.right}
-    ${styledSystem.bottom}
-    ${styledSystem.left}
+const Text = styled(Box)`
     ${styledSystem.fontFamily}
     ${styledSystem.fontSize}
     ${styledSystem.fontWeight}
@@ -31,23 +15,7 @@ const Text = styled.p`
 `;
 
 Text.propTypes = {
-  ...styledSystem.display.propTypes,
-  ...styledSystem.space.propTypes,
-  ...styledSystem.width.propTypes,
-  ...styledSystem.maxWidth.propTypes,
-  ...styledSystem.minWidth.propTypes,
-  ...styledSystem.height.propTypes,
-  ...styledSystem.maxHeight.propTypes,
-  ...styledSystem.minHeight.propTypes,
-  ...styledSystem.ratio.propTypes,
-  ...styledSystem.verticalAlign.propTypes,
-  ...styledSystem.overflow.propTypes,
-  ...styledSystem.position.propTypes,
-  ...styledSystem.zIndex.propTypes,
-  ...styledSystem.top.propTypes,
-  ...styledSystem.right.propTypes,
-  ...styledSystem.bottom.propTypes,
-  ...styledSystem.left.propTypes,
+  ...Box.propTypes,
   ...styledSystem.fontFamily.propTypes,
   ...styledSystem.fontSize.propTypes,
   ...styledSystem.fontWeight.propTypes,
@@ -55,6 +23,10 @@ Text.propTypes = {
   ...styledSystem.lineHeight.propTypes,
   ...styledSystem.letterSpacing.propTypes,
   ...styledSystem.color.propTypes
+};
+
+Text.defaultProps = {
+  tag: 'p'
 };
 
 export default Text;

--- a/packages/core/components/text/index.mdx
+++ b/packages/core/components/text/index.mdx
@@ -9,12 +9,13 @@ import Text from './'
 
 # Text
 
-Generic text element. Renders as `<p>`. Similar to `Box` but minus some layout
-functionality (flex & grid) and plus text functionality (color, fontFamily, fontSize,
-fontWeight, textAlign, lineHeight, letterSpacing).
+Generic text element. Renders as `<p>` by default. Extends `Box` with text
+functionality (color, fontFamily, fontSize, fontWeight, textAlign, lineHeight,
+letterSpacing).
 
 <Playground>
   <Text>Hey whatsup</Text>
+  <Text tag="span">Go figure, I'm a span</Text>
   <Text pl={4} color="primary" fontWeight="bold">Not much. You?</Text>
   <Text textAlign="right" fontSize={5} letterSpacing=".6em">Oh ya know. Same ol.</Text>
 </Playground>
@@ -23,23 +24,7 @@ fontWeight, textAlign, lineHeight, letterSpacing).
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| ${display} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${space} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${width} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${maxWidth} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${minWidth} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${height} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${maxHeight} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${minHeight} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${ratio} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${verticalAlign} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${overflow} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${position} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${zIndex} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${top} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${right} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${bottom} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
-| ${left} | number or string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
+| Box props | | | | see [Box](/components/box) |
 | ${fontFamily} | string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
 | ${fontSize} | string | no | | see [styled-system](https://jxnblk.com/styled-system/) |
 | ${fontWeight} | string | no | | see [styled-system](https://jxnblk.com/styled-system/) |


### PR DESCRIPTION
## Overview

Add a `tag` prop to the `Box` component. This prop expects a string that is the name of a valid html element. This element is used as the rendered html element instead of `Box`'s default `<div>`.

`tag` is inherited by all of `Box`'s descendants, so as along as each of our components ultimately extends `Box`, its rendered html element can be easily declared.

All existing components have been updated to extend `Box` (sometimes via a descendant like `Text`), so they will all inherit its styled-system mojo (`space`, etc) with this PR.

### Checklist

- [ ] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible

Are there any of the following in this PR?

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`


### Notes

`tag` is similar to styled-component's `as` prop (and relies on it under the hood), but it swaps the underlying **html element** rather than the immediate _parent component_. We've found `as` problematic because using it to swap in an html element (eg, `<Text as="span">`) jettisons all the styled-system functionality the component inherited from `Box`.

`tag` is more similar to clean-tag’s `is` prop, which does swap out the underlying html element. However, `is` also passes all of a component's custom props down to the html element as attributes, which is crufty and throws errors when those props don't use string values and/or lowercase keys.

I chose the name `tag` instead of `is` so as not to imply we're using clean-tag, and because `is` is just too similar to `as`.

Note that this does not affect the `as` prop, which can still be used to swap out the immediately extended component.