### PR TITLE
Add direction and density props to Grouper

### DIFF
--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { darken, rgba } from "polished";
 import styled, { css } from "styled-components";
-import { borderRadius, themeGet } from "styled-system";
+import { borders, borderColor, borderRadius, themeGet } from "styled-system";
 import Text from "../text";
 import Icon from "../icon";
 import { Intent } from "../../common/intent";
@@ -50,13 +50,14 @@ const StyledButton = styled(Text)`
   justify-content: center;
   align-items: center;
   outline: 0;
-  border: 0;
   line-height: 1.1;
   text-align: center;
   text-decoration: none;
   user-select: none;
   will-change: box-shadow, background-color;
   transition: 0.1s ease-in-out box-shadow, 0.1s ease-in-out background-color;
+  ${borders}
+  ${borderColor}
   ${borderRadius}
 
   ${props => buttonStates(props)}
@@ -168,6 +169,8 @@ const Button = ({
 
 Button.propTypes = {
   ...Text.propTypes,
+  ...borders.propTypes,
+  ...borderColor.propTypes,
   ...borderRadius.propTypes,
   intent: PropTypes.oneOf(Object.values(Intent)),
   appearance: PropTypes.oneOf(Object.values(Appearance)),
@@ -184,6 +187,7 @@ Button.defaultProps = {
   pb: 1,
   pl: 1,
   pr: 1,
+  border: 0,
   borderRadius: "base",
   intent: Intent.NONE,
   appearance: Appearance.DEFAULT,

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -47,7 +47,7 @@ const StyledButton = styled(Text)`
   cursor: pointer;
   display: inline-flex;
   flex-flow: row nowrap;
-  justify-contents: space-between;
+  justify-content: center;
   align-items: center;
   outline: 0;
   border: 0;

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -1,58 +1,103 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { themeGet } from "styled-system";
+import { Direction } from "../../common/direction";
+import { Density } from "../../common/density";
 import Box from "../box";
 
-const StyledGrouper = styled(Box)`
+const StyledGrouper = styled(Box).attrs(props => ({
+  leadingMargin: props.flexDirection === 'column' ? 'margin-top' : 'margin-left'
+}))`
   display: flex;
-  flex-flow: row nowrap;
-  justify-content: flex-start;
-  align-items: ${props => props.alignItems};
+  flex-wrap: nowrap;
 
   > *:focus {
     z-index: 1;
   }
 
   > * + * {
-    margin-left: ${props => themeGet(`space.${props.gutter}`, props.gutter)};
+    ${props => props.leadingMargin}: ${props => themeGet(`space.${props.gutter}`, props.gutter)};
   }
 `;
 
-const CompactGrouper = styled(StyledGrouper)`
+const CompactGrouper = styled(StyledGrouper).attrs(props => ({
+  leadingBorder: props.flexDirection === 'column' ? 'border-top' : 'border-left',
+  firstChildCorner: props.flexDirection === 'column' ? 'border-top-right-radius' : 'border-bottom-left-radius',
+  lastChildCorner: props.flexDirection === 'column' ? 'border-bottom-left-radius' : 'border-top-right-radius'
+}))`
   > * {
     border-radius: 0 !important;
   }
 
-  > * + * {
-    border-left: none;
-  }
+  ${props => props.gutter === 0 && css`
+    > * + * {
+      ${props => props.leadingBorder}: 0;
+    }
+  `}
 
   > :first-child {
     border-top-left-radius: ${props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)} !important;
-    border-bottom-left-radius: ${props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)} !important;
+    ${props => props.firstChildCorner}: ${props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)} !important;
   }
 
   > :last-child {
-    border-top-right-radius: ${props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)} !important;
+    ${props => props.lastChildCorner}: ${props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)} !important;
     border-bottom-right-radius: ${props => themeGet(`radii.${props.borderRadius}`, props.borderRadius)} !important;
   }
 `;
 
-const Grouper = props => {
-  return props.gutter === 0 ? <CompactGrouper {...props} /> : <StyledGrouper {...props} />;
+function determineDirection(direction, flexDirection) {
+  switch (direction) {
+    case Direction.VERTICAL:
+      return 'column';
+    case Direction.HORIZONTAL:
+      return 'row';
+    default:
+      return flexDirection;
+  }
+}
+
+function determineGutter(gutter, density) {
+  if (gutter !== undefined) {
+    return gutter;
+  } else if (density === Density.COMPACT) {
+    return "2px";
+  } else if (density === Density.COMFORTABLE) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+const Grouper = ({density, direction: dir, flexDirection, gutter: g, ...props}) => {
+  const direction = determineDirection(dir, flexDirection);
+  const gutter = determineGutter(g, density);
+  switch (density) {
+    case Density.COMFORTABLE:
+      return <StyledGrouper flexDirection={direction} gutter={gutter} {...props} />;
+    case Density.COMPACT:
+    default:
+      return <CompactGrouper flexDirection={direction} gutter={gutter} {...props} />;
+  }
 };
 
 Grouper.propTypes = {
   ...Box.PropTypes,
+  compact: PropTypes.bool,
+  direction: PropTypes.oneOf(Object.values(Direction)),
+  density: PropTypes.oneOf(Object.values(Density)),
   borderRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  gutter: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  alignItems: PropTypes.string
+  gutter: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 Grouper.defaultProps = {
+  direction: undefined,
+  density: Density.COMPACT,
   borderRadius: "base",
-  gutter: 0,
+  gutter: undefined,
+  flexDirection: "row",
+  justifyContent: "flex-start",
   alignItems: "stretch"
 };
 

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -7,54 +7,97 @@ route: /components/grouper
 import { Playground, PropsTable } from 'docz'
 import Grouper from './'
 import Button from '../button'
+import { Direction } from "../../common/direction";
+import { Density } from "../../common/density";
+
 
 # Grouper
 
-## Basic usage
+## Horizontal (default)
+
+`COMPACT` density (default) forces intermediate `borderRadius` to `0`,
+while `COMFORTABLE` density does not.
 
 <Playground>
-  <Grouper>
+  <Grouper mb={4}>
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+
+  <Grouper density={Density.COMFORTABLE}>
     <Button>Hello</Button>
     <Button>Crazy</Button>
     <Button>World</Button>
   </Grouper>
 </Playground>
 
-## Radius overrides
+
+## Vertical
 
 <Playground>
-  <Grouper borderRadius="0">
+  <Grouper direction={Direction.VERTICAL} mb={6}>
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+
+  <Grouper direction={Direction.VERTICAL} density={Density.COMFORTABLE}>
     <Button>Hello</Button>
     <Button>Crazy</Button>
     <Button>World</Button>
   </Grouper>
 </Playground>
+
+
+## Gutter
+
+<Playground>
+  <Grouper gutter={2} mb={8}>
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+
+  <Grouper gutter={3} direction={Direction.VERTICAL} density={Density.COMFORTABLE}>
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+</Playground>
+
+
+## Radius override
+
+`borderRadius` prop affects outer corners of first & last children only.
+Ignored if `COMFORTABLE`.
+
+<Playground>
+  <Grouper borderRadius="large">
+    <Button>Hello</Button>
+    <Button>Crazy</Button>
+    <Button>World</Button>
+  </Grouper>
+</Playground>
+
 
 ## Form
 
 <Playground>
-  <Grouper borderRadius="base">
+  <Grouper gutter={0} borderRadius="large">
     <input type="text" />
     <Button>Go</Button>
   </Grouper>
 </Playground>
 
-## Gutter
-
-<Playground>
-  <Grouper gutter="1.6rem">
-    <Button>Hello</Button>
-    <Button>Crazy</Button>
-    <Button>World</Button>
-  </Grouper>
-</Playground>
 
 
 ### PropTypes
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
 | Box props | | | | see [Box](/components/box) |
-| borderRadius | string | no | `base` | outer corners of first & last children. ignored iff `gutter`. |
-| gutter | string | no | `0` | gap between children |
-| alignItems | string | no | `stretch` | |
-| ${space} | string | no | | see [styled-system](https://jxnblk.com/styled-system/#margin--padding) |
+| flexDirection | string | no | `row` | |
+| direction | enum | no | | overrides `flexDirection`. see `common/direction` |
+| density | enum | no | Density.COMPACT | if COMPACT, interior borderRadii forced to 0. see `common/density` |
+| gutter | string or number | no | `2px` if `COMPACT`. `space.1` if `COMFORTABLE` | gap between children |
+| borderRadius | string | no | `base` | outer corners of first & last children. ignored if `COMPACT`. |


### PR DESCRIPTION
## Overview

Grouper can now arrange its children horizontally (default) or vertically, via the `direction (Direction enum)` or `flexDirection (string)` props. If both are supplied, `direction` wins.

Density can also be adjusted via the `density (Density enum)` prop. The default value is `Density.COMPACT`, which defaults to a `2px` gutter between children and forces `borderRadius` to `0` for all intermediate corners. `Density.COMFORTABLE` defaults to a `space.1` gutter and leaves intermediate `borderRadius` untouched. In either case, gutter can be customized via the `gutter` prop.

As before, the `borderRadius` prop can be used to customize the outer corners of the first and last children. It is ignored if `density === Density.COMFORTABLE`.

### Checklist

- [ ] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible

Are there any of the following in this PR?

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`

### Demo

![image](https://user-images.githubusercontent.com/128699/50247805-e8668c80-03a6-11e9-9734-fea18ff0022a.png)


Closes #107 
