### PR TITLE
Fix filtering for files method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [\#100](https://github.com/raster-foundry/blasterjs/pull/111)
+- CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [\#100](https://github.com/raster-foundry/blasterjs/pull/111)
-- CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package
+- CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [\#120](https://github.com/raster-foundry/blasterjs/pull/120)
 
 ### Security
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -113,7 +113,7 @@ const templatesPath = "./templates";
 const dirs = p =>
   readdirSync(p).filter(f => statSync(join(p, f)).isDirectory());
 
-const files = p => readdirSync(p).filter(f => statSync(join(p, f)).isFile());
+const files = (p, ext="") => readdirSync(p).filter(f => statSync(join(p, f)).isFile() && (ext ? f.endsWith(`.${ext}`) : true));
 
 const packagePath = package => `./packages/${package}`;
 
@@ -129,7 +129,7 @@ const listComponentsInPackage = package =>
   dirs(`${packagePath(package)}/components`);
 
 const listConstantsInPackage = package =>
-  files(`${packagePath(package)}/common`).map(f => f.replace(/\.[^/.]+$/, ""));
+  files(`${packagePath(package)}/common`, "js").map(f => f.replace(/\.[^/.]+$/, ""));
 
 const packageExists = package => listPackages().includes(package);
 
@@ -200,7 +200,7 @@ const optimizeSvgFile = async (svgPath) => {
 const generateIconIndex = async () => {
   try {
     const indexFile = "./packages/core/index.icons.js";
-    const svgs = files("./icons").filter(f => f.includes(".svg"));
+    const svgs = files("./icons", "svg");
     // Generate camelcased names
     const svgArrays = await Promise.all(
       svgs.map(async f => {


### PR DESCRIPTION
## Overview

This PR adds extension filtering to the `files` method within the CLI and then uses that functionality to properly filter for `.js` files when generating the common index for each package.

### Checklist

- [NA] Relevant documentation pages have been created or updated
- [x] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible

## Testing Instructions

 * Pull down the branch
 * Delete the contents of the core package's `index.common.js` file
 * `blaster i`
 * Verify that the `README.md` file did not show up in the `index.common.js` file and that the other files were properly referenced

Closes #119 
