### PR TITLE
Fix font issues in documentation and blaster components

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="{{ description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500,600,700|Source+Code+Pro:400,600|Source+Sans+Pro:200,300,400,600,700"
+  <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500,600,700|Source+Code+Pro:400,600|Open+Sans:300,400,600,700"
     rel="stylesheet">
   <title>{{ title }}</title>
   {{ head }}

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,8 @@
   <meta name="description" content="{{ description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500,600,700|Source+Code+Pro:400,600" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500,600,700|Source+Code+Pro:400,600|Source+Sans+Pro:200,300,400,600,700"
+    rel="stylesheet">
   <title>{{ title }}</title>
   {{ head }}
 </head>

--- a/packages/core/components/globalStyle/index.js
+++ b/packages/core/components/globalStyle/index.js
@@ -54,11 +54,6 @@ const GlobalStyle = createGlobalStyle`
     html {
       font-size: 62.5%;
     }
-    body {
-      font-family: ${themeGet('fonts.body')};
-      font-size: 15px;
-      font-size: ${themeGet('fontSizes.2')};
-    }
 `;
 
 export default GlobalStyle;

--- a/packages/core/components/globalStyle/index.js
+++ b/packages/core/components/globalStyle/index.js
@@ -3,7 +3,7 @@ import { createGlobalStyle } from "styled-components";
 import { themeGet } from "styled-system";
 
 const GlobalStyle = createGlobalStyle`
-    html, body, div, span, applet, object, iframe,
+    div, span, applet, object, iframe,
     h1, h2, h3, h4, h5, h6, p, blockquote, pre,
     a, abbr, acronym, address, big, cite, code,
     del, dfn, em, img, ins, kbd, q, s, samp,
@@ -28,8 +28,13 @@ const GlobalStyle = createGlobalStyle`
     footer, header, hgroup, menu, nav, section {
     display: block;
     }
-    body {
+    body,
+    html {
     line-height: 1;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    vertical-align: baseline;
     }
     ol, ul {
     list-style: none;

--- a/packages/core/components/globalStyle/index.js
+++ b/packages/core/components/globalStyle/index.js
@@ -30,7 +30,6 @@ const GlobalStyle = createGlobalStyle`
     }
     body,
     html {
-    line-height: 1;
     margin: 0;
     padding: 0;
     border: 0;

--- a/packages/core/components/text/index.js
+++ b/packages/core/components/text/index.js
@@ -28,7 +28,8 @@ Text.propTypes = {
 Text.defaultProps = {
   tag: 'p',
   fontFamily: 'body',
-  fontSize: 2
+  fontSize: 2,
+  lineHeight: 1
 };
 
 export default Text;

--- a/packages/core/components/text/index.js
+++ b/packages/core/components/text/index.js
@@ -26,7 +26,9 @@ Text.propTypes = {
 };
 
 Text.defaultProps = {
-  tag: 'p'
+  tag: 'p',
+  fontFamily: 'body',
+  fontSize: 2
 };
 
 export default Text;

--- a/packages/core/defaultTheme.js
+++ b/packages/core/defaultTheme.js
@@ -63,7 +63,7 @@ const colors = {
 };
 
 const fonts = {
-  body: "'Libre Franklin', sans-serif",
+  body: "'Open Sans', sans-serif",
   display: "'Libre Franklin', sans-serif",
   code: "'Source Code Pro', monospace"
 };


### PR DESCRIPTION
## Overview
Docz wasn't fetching Source Sans Pro correctly so the layout of the documentation pages we're getting messed up. This adds the font to our google fonts cdn declaration.