### PR TITLE
Organize docs sidebar into Components, Controls, Navigation, Overlays

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -10,7 +10,7 @@ export default {
     "React Styled-components UI library designed and built by Azavea",
   indexHtml: "docs/index.html",
   wrapper: "docs/wrapper.js",
-  menu: ["Home", "Getting Started", "Components", "Overlays"],
+  menu: ["Home", "Getting Started", "Components", "Controls", "Navigation", "Overlays"],
   codeSandbox: false,
   themeConfig: {
     showPlaygroundEditor: true

--- a/packages/core/components/brand/index.mdx
+++ b/packages/core/components/brand/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Brand
-menu: Components
-route: /components/brand
+menu: Navigation
+route: /navigation/brand
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/breadcrumbs/index.mdx
+++ b/packages/core/components/breadcrumbs/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Breadcrumbs
-menu: Components
-route: /components/breadcrumbs
+menu: Navigation
+route: /navigation/breadcrumbs
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/button/index.mdx
+++ b/packages/core/components/button/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Button
-menu: Components
-route: /components/button
+menu: Controls
+route: /controls/button
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/checkbox/index.mdx
+++ b/packages/core/components/checkbox/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Checkbox
-menu: Components
-route: /components/checkbox
+menu: Controls
+route: /controls/checkbox
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/colorInput/index.mdx
+++ b/packages/core/components/colorInput/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: ColorInput
-menu: Components
-route: /components/colorInput
+menu: Controls
+route: /controls/colorInput
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/field/index.mdx
+++ b/packages/core/components/field/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Field
-menu: Components
-route: /components/field
+menu: Controls
+route: /controls/field
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/fileInput/index.mdx
+++ b/packages/core/components/fileInput/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: FileInput
-menu: Components
-route: /components/fileInput
+menu: Controls
+route: /controls/fileInput
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/label/index.mdx
+++ b/packages/core/components/label/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Label
-menu: Components
-route: /components/label
+menu: Controls
+route: /controls/label
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/navBar/index.mdx
+++ b/packages/core/components/navBar/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: NavBar
-menu: Components
-route: /components/navBar
+menu: Navigation
+route: /navigation/navBar
 ---
 
 import { Playground, PropsTable } from 'docz';

--- a/packages/core/components/radio/index.mdx
+++ b/packages/core/components/radio/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Radio
-menu: Components
-route: /components/radio
+menu: Controls
+route: /controls/radio
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/select/index.mdx
+++ b/packages/core/components/select/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Select
-menu: Components
-route: /components/select
+menu: Controls
+route: /controls/select
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/textInput/index.mdx
+++ b/packages/core/components/textInput/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: TextInput
-menu: Components
-route: /components/textInput
+menu: Controls
+route: /controls/textInput
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/textarea/index.mdx
+++ b/packages/core/components/textarea/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Textarea
-menu: Components
-route: /components/textarea
+menu: Controls
+route: /controls/textarea
 ---
 
 import { Playground, PropsTable } from 'docz'

--- a/packages/core/components/toggleField/index.mdx
+++ b/packages/core/components/toggleField/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: ToggleField
-menu: Components
-route: /components/toggleField
+menu: Controls
+route: /controls/toggleField
 ---
 
 import { Playground, PropsTable } from 'docz'


### PR DESCRIPTION
## Overview

Organize existing components' docs pages into sidebar categories:
- Components
- Controls
- Navigation
- Overlays


### Checklist

- [ ] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible

Are there any of the following in this PR?

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`


### Demo

![image](https://user-images.githubusercontent.com/128699/52726875-0bb25000-2f82-11e9-99fd-4b144b7d16d7.png)

Closes #134 
