### PR TITLE
Fix tooltip arrows and field labels

### DIFF
--- a/packages/core/components/field/index.js
+++ b/packages/core/components/field/index.js
@@ -86,7 +86,7 @@ const Field = ({
           {reverse && children}
           <Box width={nameWidth} ml={reverse ? 2 : 0} mr={reverse ? 0 : 2}>
             <Name
-              tag="h6"
+              tag="span"
               minHeight={reverse ? 0 : "4rem"}
               display="flex"
               alignItems="center"
@@ -116,7 +116,7 @@ const Field = ({
       return (
         <StyledField flexDirection="column" {...props}>
           <Name
-            tag="h6"
+            tag="span"
             width={nameWidth}
             mb={size === Size.TINY || Size.SMALL ? 1 : 2}
             disabled={disabled}

--- a/packages/core/components/tooltip/index.js
+++ b/packages/core/components/tooltip/index.js
@@ -25,8 +25,8 @@ const TooltipContent = styled.span`
     border-color: ${props => themeGet(`colors.${props.bg}`, props.bg)};
   }
 
-  ${props => props.placement && props.placement.startsWith('top') && css`
-    bottom: 5px;
+  .tooltip[x-placement^="top"] & {
+    bottom: 2px;
     margin-bottom: 5px;
 
     .tooltip-arrow {
@@ -39,10 +39,10 @@ const TooltipContent = styled.span`
       margin-top: 0;
       margin-bottom: 0;
     }
-  `}
+  }
 
-  ${props => props.placement && props.placement.startsWith('bottom') && css`
-    top: 5px;
+  .tooltip[x-placement^="bottom"] & {
+    top: 2px;
     margin-top: 5px;
 
     .tooltip-arrow {
@@ -55,9 +55,9 @@ const TooltipContent = styled.span`
       margin-top: 0;
       margin-bottom: 0;
     }
-  `}
+  }
 
-  ${props => props.placement && props.placement.startsWith('right') && css`
+  .tooltip[x-placement^="right"] & {
     margin-left: 5px;
 
     .tooltip-arrow {
@@ -70,9 +70,9 @@ const TooltipContent = styled.span`
       margin-left: 0;
       margin-right: 0;
     }
-  `}
+  }
 
-  ${props => props.placement && props.placement.startsWith('left') && css`
+  .tooltip[x-placement^="left"] & {
     margin-right: 5px;
 
     .tooltip-arrow {
@@ -85,7 +85,7 @@ const TooltipContent = styled.span`
       margin-left: 0;
       margin-right: 0;
     }
-  `}
+  }
 `;
 
 class Tooltip extends React.Component {


### PR DESCRIPTION
## Overview

Quick fixes:

- Use `span` instead of `h6` for inner labels of Field component #139 

- Ensure tooltip arrows point in the right direction when automatically repositioned due to overflow #140 

### Checklist

- [ ] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


Are there any of the following in this PR?


- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project


If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`

### Demo

![image](https://user-images.githubusercontent.com/128699/53117294-92ce6d80-3518-11e9-9e91-591d46b3f369.png)



Closes #139 
Closes #140 
