### PR TITLE
Add 'Blaster' component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,29 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added Blaster application wrapper component [#173](https://github.com/raster-foundry/blasterjs/pull/173)
+
 ## [0.0.16] - 2019-03-20 [YANKED]
 
 ## [0.0.15] - 2019-03-20 [YANKED]
 
 ## [0.0.14] - 2019-03-11
+
 ### Added
+
 - Added chan for changelog management
 
 ## 0.0.14-alpha.1 - 2019-03-11
+
 ### Added
+
 - `Divider` component added to the core package [#94](https://github.com/raster-foundry/blasterjs/pull/94)
 - `Icon` component added to the core package [#103](https://github.com/raster-foundry/blasterjs/pull/103)
 - `Box` component added to the core package [#112](https://github.com/raster-foundry/blasterjs/pull/112)
@@ -27,15 +36,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Table` components added to the core package [#132](https://github.com/raster-foundry/blasterjs/pull/132)
 
 ### Changed
+
 - Changed theme file `radius` to `radii` (breaking change for custom themes)
 - Normalized usage of styled-system across every component
 - Renamed `Link` to `A`.
 - Refactored theme system to support per-component themeing, replacing `defaultTheme.js` with a `theme` folder [#129](https://github.com/raster-foundry/blasterjs/pull/129)
 
 ### Removed
+
 - Removed reset.css.
 
 ### Fixed
+
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [#100](https://github.com/raster-foundry/blasterjs/pull/111)
 - CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [#120](https://github.com/raster-foundry/blasterjs/pull/120)
 

--- a/docs/GettingStarted.mdx
+++ b/docs/GettingStarted.mdx
@@ -6,31 +6,44 @@ route: /getting-started
 
 # Getting started
 
-## Theme Provider
+The [`Blaster`](/components/blaster) component is an application wrapper that performs the necessary work of scaffolding global styles and providing a default theme.
 
-Wrap the root of your application with the ThemeProvider component. This should only be included once in your application.
-
-The ThemeProvider is a wrapper around styled-components' ThemeProvider.
-
-Include `<GlobalStyle/>` to reset CSS.
+## Basic Application Wrapper Setup
 
 ```jsx static
 import React from "react";
-import { ThemeProvider } from "styled-components";
-import { GlobalStyle, theme } from "@blasterjs/core";
-// or
-// import { MyCustomTheme } from '../your-custom-theme'
+import { Blaster } from "@blasterjs/core";
 
 class App extends React.Component {
   render() {
     return (
-        <ThemeProvider theme={theme}>
-            <>
-                <GlobalStyle />
-                {props.children}
-            </>
-        </ThemeProvider>
+        <Blaster>
+          <AppContentGoesHere />
+        </Blaster>
     );
   }
 }
 ```
+
+## Custom Theme Application Wrapper Setup
+
+The [`Blaster`](/components/blaster) component also handles custom theme injection.
+
+```jsx static
+import React from "react";
+import { Blaster } from "@blasterjs/core";
+
+import { MyCustomTheme } from '../your-custom-theme'
+
+class App extends React.Component {
+  render() {
+    return (
+        <Blaster theme={MyCustomTheme}>
+          <AppContentGoesHere />
+        </Blaster>
+    );
+  }
+}
+```
+
+See the documentation on the [`Blaster`](/components/blaster) component for more usage information.

--- a/docs/wrapper.js
+++ b/docs/wrapper.js
@@ -1,15 +1,3 @@
-import React, { Component } from "react";
-import styled, { ThemeProvider } from "styled-components";
-import { theme } from "../packages/core/theme";
-import GlobalStyle from "../packages/core/components/globalStyle"
+import { Blaster } from "../packages/core";
 
-const Wrapper = ({ children }) => (
-  <ThemeProvider theme={{ ...theme }}>
-    <>
-      <GlobalStyle />
-      {children}
-    </>
-  </ThemeProvider>
-);
-
-export default Wrapper;
+export default Blaster;

--- a/packages/core/components/blaster/index.js
+++ b/packages/core/components/blaster/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { ThemeProvider } from "styled-components";
+import merge from "lodash.merge";
+
+import { theme as defaultTheme } from "../../theme";
+import GlobalStyle from "../globalStyle";
+
+export default ({ children, theme }) => (
+  <ThemeProvider theme={merge(defaultTheme, theme || {})}>
+    <>
+      <GlobalStyle />
+      {children}
+    </>
+  </ThemeProvider>
+);

--- a/packages/core/components/blaster/index.mdx
+++ b/packages/core/components/blaster/index.mdx
@@ -1,0 +1,59 @@
+---
+name: Blaster
+menu: Components
+route: /components/blaster
+---
+
+# Blaster
+
+The `Blaster` component is wrapper for your entire application.
+It does a few things:
+- inserts the necessary global styles to make your application look its best
+- provides a default theme to all components rendered within
+- allows overriding and merging of theme styles
+
+## Using the default theme
+```
+  import React from "react";
+  import { Blaster, Card } from "@blasterjs/core";
+
+  export default () => (
+    <Blaster>
+      <Card bg="primary">
+        Hello
+      </Card>
+      <Card bg="secondary">
+        World
+      </Card>
+    </Blaster>
+  ) ;
+```
+
+## Overriding the default theme
+```
+  import React from "react";
+  import { Blaster, Badge } from "@blasterjs/core";
+
+  const newTheme = {
+    colors: {
+      primary: 'blue',
+      secondary: 'red'
+    }
+  };
+
+  export default () => (
+    <Blaster theme={ newTheme }>
+      <Card bg="primary">
+        Hello
+      </Card>
+      <Card bg="secondary">
+        World
+      </Card>
+    </Blaster>
+  ) ;
+```
+
+### PropTypes
+| Prop | Type | Required | Default | Description |
+|:-----|:-----|:---------|:--------|:------------|
+| theme | object | no | see default theme | The theme to use for components within this tag. The theme object provided will be merged with the default theme |

--- a/packages/core/components/blaster/index.mdx
+++ b/packages/core/components/blaster/index.mdx
@@ -6,7 +6,7 @@ route: /components/blaster
 
 # Blaster
 
-The `Blaster` component is wrapper for your entire application.
+The `Blaster` component is a wrapper for your entire application.
 It does a few things:
 - inserts the necessary global styles to make your application look its best
 - provides a default theme to all components rendered within

--- a/packages/core/index.components.js
+++ b/packages/core/index.components.js
@@ -1,5 +1,6 @@
 export { default as A } from "./components/a";
 export { default as Badge } from "./components/badge";
+export { default as Blaster } from "./components/blaster";
 export { default as Box } from "./components/box";
 export { default as Brand } from "./components/brand";
 export { default as Breadcrumbs } from "./components/breadcrumbs";

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blasterjs/core",
-  "version": "0.0.14",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -116,6 +116,11 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "src/index.js",
   "dependencies": {
+    "lodash.merge": "^4.6.1",
     "polished": "^2.0.1",
     "react-modal": "^3.8.1",
     "styled-components": "^4.1.2",


### PR DESCRIPTION
## Overview

This PR adds a new component: `Blaster`.

This component is intended to be used as a application wrapper that handles inserting global styles, providing a default theme, and merging any user provided theme styles with the default theme.

This PR also updates the Docz wrapper to use this component.

### Checklist

- [x] Relevant documentation pages have been created or updated
- [x] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


## Testing Instructions

 * In the Docz wrapper, (`/docs/wrapper.js`), modify the wrapper to incorporate some obvious theme style changes:

```
import React from "react";
import { Blaster } from "../packages/core";

const newTheme = {
  colors: {
    primary: 'blue',
    secondary: 'red'
  }
};

export default ({ children }) => (
  <Blaster theme={newTheme}> {children} </Blaster>
);
```
* start up docz: `nvm use && npm run docz`
* navigate to the Card component doc page and modify the cards to have a `bg="primary"` or `bg="secondary"` prop and notice that these changes match the colors defined in your custom theme

Closes #148 
