### PR TITLE
 created a buildTheme utility for theme overrides

### DIFF
--- a/packages/core/theme/index.js
+++ b/packages/core/theme/index.js
@@ -1,37 +1,9 @@
 import * as base from "./base";
 import * as components from "./components";
 import icons from "./icons";
+import { buildTheme } from "../utils";
+import merge from "lodash.merge";
 
-// Copy `base` and `icons` to `theme`
-export const theme = { ...base, icons };
+export const theme = { ...buildTheme(components, base), icons };
 
-console.log(theme)
-
-// Resolve references to base theme throughout component themes
-// eg, `link.space.mx: 2` -> `link.space.mx: '1.6rem'`
-// eg, `link.colors.hoverColor: 'primary'` -> `link.colors.hoverColor: '#738FFC'`
-for (var component in components) {
-  const componentTheme = components[component];
-  for (var themeCategory in componentTheme) {
-    if (["icons", "__filemeta"].includes(themeCategory)) continue;
-    // lest we want to resolve icon names with their SVG strings
-
-    const categoryDetails = componentTheme[themeCategory];
-    for (var key in categoryDetails) {
-      const value = categoryDetails[key];
-      const resolvedValue = base[themeCategory][value];
-      if (resolvedValue !== undefined && resolvedValue !== null) {
-        categoryDetails[key] = resolvedValue;
-      } else {
-        categoryDetails[key] = value;
-      }
-    }
-
-    // Attach component theme category objects to base theme category objects
-    // eg, `theme.space.link = { mx: '1.6rem', my: '0.8rem', ... }`
-    // eg, `theme.colors.link = { hoverColor: '#738FFC', ... }`
-    // So namespaced styled-system defaultProps just work
-    // eg, `Link.defaultProps = { mr: 'link.mx', ml: 'link.mx', ... }`
-    theme[themeCategory][component] = categoryDetails;
-  }
-}
+console.log(theme);

--- a/packages/core/utils.js
+++ b/packages/core/utils.js
@@ -45,6 +45,5 @@ export const buildTheme = (components, base) => {
       theme[themeCategory][component] = categoryDetails;
     }
   }
-  console.log(theme);
   return theme;
 };

--- a/packages/core/utils.js
+++ b/packages/core/utils.js
@@ -12,3 +12,39 @@ export const extractComponentFromChildren = (_children, componentName) => {
   });
   return [children, component];
 };
+
+export const buildTheme = (components, base) => {
+  // Resolve references to base theme throughout component themes
+  // eg, `link.space.mx: 2` -> `link.space.mx: '1.6rem'`
+  // eg, `link.colors.hoverColor: 'primary'` -> `link.colors.hoverColor: '#738FFC'`
+
+  let theme = { ...base };
+  for (var component in components) {
+    const componentTheme = components[component];
+    for (var themeCategory in componentTheme) {
+      if (["icons", "__filemeta"].includes(themeCategory)) continue;
+      // lest we want to resolve icon names with their SVG strings
+
+      const categoryDetails = componentTheme[themeCategory];
+      for (var key in categoryDetails) {
+        const value = categoryDetails[key];
+        const resolvedValue = base[themeCategory][value];
+        if (resolvedValue !== undefined && resolvedValue !== null) {
+          categoryDetails[key] = resolvedValue;
+        } else {
+          categoryDetails[key] = value;
+        }
+      }
+
+      // Attach component theme category objects to base theme category objects
+      // eg, `theme.space.link = { mx: '1.6rem', my: '0.8rem', ... }`
+      // eg, `theme.colors.link = { hoverColor: '#738FFC', ... }`
+      // So namespaced styled-system defaultProps just work
+      // eg, `Link.defaultProps = { mr: 'link.mx', ml: 'link.mx', ... }`
+      theme[themeCategory] = theme[themeCategory] || {};
+      theme[themeCategory][component] = categoryDetails;
+    }
+  }
+  console.log(theme);
+  return theme;
+};

--- a/theme-examples/basic-theme/components.js
+++ b/theme-examples/basic-theme/components.js
@@ -1,0 +1,14 @@
+import { css } from "styled-components";
+
+export default {
+  header: {
+    {
+      colors: {
+        color: "red"
+      }
+      styles: css`
+        text-transform: uppercase;
+      `
+    }
+  }
+}

--- a/theme-examples/basic-theme/index.js
+++ b/theme-examples/basic-theme/index.js
@@ -1,0 +1,68 @@
+import { buildTheme } from "@blasterjs/core/utils";
+import components from "./components";
+
+export default buildTheme(components, {
+  colors: {
+    // Base color overrides
+    primary: "red",
+    secondary: "#333"
+  },
+  fonts: {
+    // Base font overrides
+    body: "'Roboto', sans-serif;"
+  },
+  fontSizes: [
+    // Base font-size overrides
+  ],
+  radii: {
+    // Base border-radius overrides
+  },
+  shadows: [
+    // Base box-shadow overrides
+  ],
+  space: [
+    // Base space overrides
+  ],
+  lineHeights: {
+    // Base line-height overrides
+  },
+  fontWeights: {
+    // Base font-weight overrides
+  },
+  letterSpacings: {
+    // Base letter-spacing overrides
+  },
+  maxWidths: {
+    // Base max-width overrides
+  },
+  minWidths: {
+    // Base min-width overrides
+  },
+  widths: {
+    // Base width overrides
+  },
+  maxHeights: {
+    // Base max-height overrides
+  },
+  minHeights: {
+    // Base min-height overrides
+  },
+  heights: {
+    // Base height overrides
+  },
+  borders: {
+    // Base border overrides
+  },
+  borderWidths: {
+    // Base border-width overrides
+  },
+  borderStyles: {
+    // Base border-style overrides
+  },
+  zIndices: {
+    // Base z-index overrides
+  },
+  styles: {
+    // Base style overrides
+  }
+});


### PR DESCRIPTION
## Overview

- add buildTheme() utility function for default theme and theme overrides
- added a theme-examples directory

### Checklist

- [ ] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


Are there any of the following in this PR?
- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project


If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`