### PR TITLE
update heading to utilize style props, new docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Renamed `Header` to `Heading`
+- Updated Heading to utilize Styled Props
+- Moved Blaster component docs to Primitives menu
 
-## [0.0.19] - 2019-04-19 [YANKED]
+### Added
+- new documentation for Blaster Theme and Styled Props
 
-## [0.0.18] - 2019-04-19 [YANKED]
+## [0.0.19] - 2019-04-19
+
+## [0.0.18] - 2019-04-19
 
 ## [0.0.17] - 2019-04-19
 ### Added
 - Added Blaster application wrapper component [#173](https://github.com/raster-foundry/blasterjs/pull/173)
 
-## [0.0.16] - 2019-03-20 [YANKED]
+## [0.0.16] - 2019-03-20
 
-## [0.0.15] - 2019-03-20 [YANKED]
+## [0.0.15] - 2019-03-20
 
 ## [0.0.14] - 2019-03-11
 ### Added
@@ -49,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [#100](https://github.com/raster-foundry/blasterjs/pull/111)
 - CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [#120](https://github.com/raster-foundry/blasterjs/pull/120)
 
-[unreleased]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.19...HEAD
+[Unreleased]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.19...HEAD
 [0.0.19]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.17...v0.0.18
 [0.0.17]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.16...v0.0.17

--- a/docs/BlasterTheme.mdx
+++ b/docs/BlasterTheme.mdx
@@ -1,0 +1,28 @@
+---
+name: Blaster Theme
+route: /blaster-theme
+---
+import * as baseTheme from '../packages/core/theme/base';
+
+export let fileMetaFilter = function (key, value) {
+    if(key === '__filemeta') {
+        return;
+    }
+    return value;
+};
+
+# Style Props
+
+BlasterJS Components come with built-in access to the default Blaster theme, by wrapping your application with the `Blaster` component. The theme file contains predefined values for common variables such as color, fonts, spacing and more. The Blaster theme structure is based on Styled-System's [theme specification](https://styled-system.com/theme-specification/#key-reference).
+
+The Style Props on our components give direct access to the theme keys. For example, if you'd like to set the `border-radius` on a `<Box>` you can specify a value in the theme: `<Box borderRadius="small">`.
+
+With the help of Styled-System, this will automatically do a lookup to find the value of the key `radii.small` in the theme and applies the corresponding CSS.
+
+Our base theme is as follows:
+
+<pre>
+  {JSON.stringify(baseTheme, fileMetaFilter, '\t')}
+</pre>
+
+To understand how to customize the theme, see the [documentation]((/primitives/blaster)) on the `Blaster` component.

--- a/docs/BlasterTheme.mdx
+++ b/docs/BlasterTheme.mdx
@@ -11,7 +11,7 @@ export let fileMetaFilter = function (key, value) {
     return value;
 };
 
-# Style Props
+# Blaster Theme
 
 BlasterJS Components come with built-in access to the default Blaster theme, by wrapping your application with the `Blaster` component. The theme file contains predefined values for common variables such as color, fonts, spacing and more. The Blaster theme structure is based on Styled-System's [theme specification](https://styled-system.com/theme-specification/#key-reference).
 

--- a/docs/GettingStarted.mdx
+++ b/docs/GettingStarted.mdx
@@ -6,7 +6,7 @@ route: /getting-started
 
 # Getting started
 
-The [`Blaster`](/components/blaster) component is an application wrapper that performs the necessary work of scaffolding global styles and providing a default theme.
+The [`Blaster`](/primitives/blaster) component is an application wrapper that performs the necessary work of scaffolding global styles and providing a default theme.
 
 ## Basic Application Wrapper Setup
 
@@ -27,7 +27,7 @@ class App extends React.Component {
 
 ## Custom Theme Application Wrapper Setup
 
-The [`Blaster`](/components/blaster) component also handles custom theme injection.
+The [`Blaster`](/primitives/blaster) component also handles custom theme injection.
 
 ```jsx static
 import React from "react";
@@ -46,4 +46,4 @@ class App extends React.Component {
 }
 ```
 
-See the documentation on the [`Blaster`](/components/blaster) component for more usage information.
+See the documentation on the [`Blaster`](/primitives/blaster) component for more usage information.

--- a/docs/Home.mdx
+++ b/docs/Home.mdx
@@ -1,7 +1,6 @@
 ---
 name: Home
 route: /
-order: -1
 ---
 
 # BlasterJS

--- a/docs/StyleProps.mdx
+++ b/docs/StyleProps.mdx
@@ -1,0 +1,25 @@
+---
+name: Style Props
+route: /style-props
+---
+
+# Style Props
+
+BlasterJS Components utilize a standardized approach to a prop-based style system called "style props". Using [styled-system](https://styled-system.com/), groups of props are automatically applied to each component. Most components get the `COMMON` set of props which give the component access to color, space and display props (margin, padding, color, background color and display).
+
+To check which system props each component includes, see the documentation for that component.
+
+Take a look at Styled-Sytem's [Reference table](https://styled-system.com/table) and [API](https://styled-system.com/api) for more information on individual props.
+
+## Style Props categories
+| Category | Included Props |
+|:---------|:---------------|
+| `COMMON` | color, display, space |
+| `BORDER` | borders, borderColor, borderRadius |
+| `BACKGROUND` | background, backgroundColor, backgroundImage, backgroundSize, backgroundPosition, backgroundRepeat |
+| `TYPOGRAPHY` | textDecoration, textOverflow, textShadow, fontFamily, fontSize, fontStyle, fontWeight, lineHeight, textAlign, letterSpacing |
+| `LAYOUT` | size, width, height, minWidth, minHeight, maxWidth, maxHeight, overflow, verticalAlign |
+| `POSITION` | position, zIndex, top, right, bottom, left |
+| `FLEX_CONTAINER` | flexBasis, flexDirection, flexWrap, alignContent, alignItems, justifyContent, justifyItems |
+| `FLEX_ITEM` | flex, justifySelf, alignSelf, order |
+| `MISC` | opacity, boxShadow |

--- a/doczrc.js
+++ b/doczrc.js
@@ -12,9 +12,9 @@ export default {
   wrapper: "docs/wrapper.js",
   menu: [
     "Home",
+    "Getting Started",
     "Style Props",
     "Blaster Theme",
-    "Getting Started",
     "Primitives",
     "Typography",
     "Components",

--- a/doczrc.js
+++ b/doczrc.js
@@ -12,6 +12,8 @@ export default {
   wrapper: "docs/wrapper.js",
   menu: [
     "Home",
+    "Style Props",
+    "Blaster Theme",
     "Getting Started",
     "Primitives",
     "Typography",

--- a/packages/core/components/blaster/index.mdx
+++ b/packages/core/components/blaster/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Blaster
-menu: Components
-route: /components/blaster
+menu: Primitives
+route: /primitives/blaster
 ---
 
 # Blaster

--- a/packages/core/components/callout/index.js
+++ b/packages/core/components/callout/index.js
@@ -27,7 +27,7 @@ const CalloutIcon = styled(Icon)`
   margin: 0 ${themeGet("space.2", "1.6rem")};
 `;
 
-const CalloutTitle = styled(Heading).attrs({ tag: "h4" })`
+const CalloutTitle = styled(Heading).attrs({ as: "h4" })`
   margin-bottom: ${themeGet("space.1", "0.8rem")};
   line-height: 1;
 `;

--- a/packages/core/components/card/index.mdx
+++ b/packages/core/components/card/index.mdx
@@ -42,8 +42,8 @@ Composes a [`Box`](/typography/box) with preset styles.
 
 <Playground>
   <Card density="comfortable">
-    <Heading tag="h4">Hello world</Heading>
-    <Text tag="p" mb="30px">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Id magni repellendus illum quasi, officiis assumenda facere inventore accusamus maiores soluta, qui quibusdam et, dolorum tempora ab a unde porro eligendi!</Text>
+    <Heading as="h4">Hello world</Heading>
+    <Text as="p" mb="30px">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Id magni repellendus illum quasi, officiis assumenda facere inventore accusamus maiores soluta, qui quibusdam et, dolorum tempora ab a unde porro eligendi!</Text>
     <Button appearance="prominent">Continue</Button>
     <Button appearance="minimal">Cancel</Button>
   </Card>
@@ -58,10 +58,10 @@ Composes a [`Box`](/typography/box) with preset styles.
     bg="primaryTint"
     borderColor="primaryShade"
   >
-    <Heading tag="h4">
+    <Heading as="h4">
       Congratulations!
     </Heading>
-    <Text tag="p" mb="30px">
+    <Text as="p" mb="30px">
       Lorem ipsum dolor, sit amet consectetur adipisicing elit. Id magni repellendus illum quasi, officiis assumenda facere inventore accusamus maiores soluta, qui quibusdam et, dolorum tempora ab a unde porro eligendi!
     </Text>
     <Button appearance="prominent">Continue</Button>

--- a/packages/core/components/heading/index.js
+++ b/packages/core/components/heading/index.js
@@ -2,9 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { themeGet } from "styled-system";
-import Text from "../text";
+import { COMMON, TYPOGRAPHY, MISC, LAYOUT } from "../../constants";
 
-const Heading = styled(Text)`
+const Heading = styled.h1`
+  color: ${themeGet("colors.heading.color")};
+  font-family: ${themeGet("fonts.heading.fontFamily")};
+  font-weight: ${themeGet("fontWeights.heading.fontWeight")};
+  line-height: ${themeGet("lineHeights.heading.lineHeight")};
+  margin-top: ${themeGet("space.heading.m")};
+
   ${props => {
     const size = {
       h1: 7,
@@ -13,7 +19,7 @@ const Heading = styled(Text)`
       h4: 4,
       h5: 3,
       h6: 2
-    }[props.tag];
+    }[props.as];
 
     return css`
       font-size: ${props => themeGet(`fontSizes.${size}`)};
@@ -21,23 +27,22 @@ const Heading = styled(Text)`
   }}
 
   ${themeGet("styles.heading")};
+  ${COMMON}
+  ${LAYOUT}
+  ${MISC}
+  ${TYPOGRAPHY}
 `;
 
 Heading.propTypes = {
-  ...Text.propTypes,
-  tag: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6"])
+  ...COMMON.propTypes,
+  ...LAYOUT.propTypes,
+  ...MISC.propTypes,
+  ...TYPOGRAPHY.propTypes,
+  as: PropTypes.oneOf(["h1", "h2", "h3", "h4", "h5", "h6"])
 };
 
 Heading.defaultProps = {
-  tag: "h1",
-  color: "heading.color",
-  fontFamily: "heading.fontFamily",
-  fontWeight: "heading.fontWeight",
-  lineHeight: "heading.lineHeight",
-  mt: "heading.m",
-  mb: "heading.m",
-  ml: "heading.m",
-  mr: "heading.m"
+  as: "h1"
 };
 
 export default Heading;

--- a/packages/core/components/heading/index.mdx
+++ b/packages/core/components/heading/index.mdx
@@ -14,7 +14,7 @@ import Heading from './'
 
 ## Basic Usage
 
-Composes [`Text`](/typography/text) and renders an `<h1>` by default.
+The `<Heading>` component renders an `<h1>` with basic styles by default.
 
 <Playground>
   <Heading>Heading 1</Heading>

--- a/packages/core/components/heading/index.mdx
+++ b/packages/core/components/heading/index.mdx
@@ -22,15 +22,15 @@ Composes [`Text`](/typography/text) and renders an `<h1>` by default.
 
 ## Changing heading tag
 
-Use the `tag` prop to change from the default `h1` element to `h2`, `h3`, `h4`, `h5`, or `h6`.
+Use the `as` prop to change from the default `h1` element to `h2`, `h3`, `h4`, `h5`, or `h6`.
 
 <Playground>
-  <Heading tag="h1">Heading 1</Heading>
-  <Heading tag="h2">Heading 2</Heading>
-  <Heading tag="h3">Heading 3</Heading>
-  <Heading tag="h4">Heading 4</Heading>
-  <Heading tag="h5">Heading 5</Heading>
-  <Heading tag="h6">Heading 6</Heading>
+  <Heading as="h1">Heading 1</Heading>
+  <Heading as="h2">Heading 2</Heading>
+  <Heading as="h3">Heading 3</Heading>
+  <Heading as="h4">Heading 4</Heading>
+  <Heading as="h5">Heading 5</Heading>
+  <Heading as="h6">Heading 6</Heading>
 </Playground>
 
 ## Styling headings
@@ -44,10 +44,11 @@ Use the `tag` prop to change from the default `h1` element to `h2`, `h3`, `h4`, 
 
 | Prop | Type | Required | Default | Description |
 |:-----|:-----|:---------|:--------|:------------|
-| Text props | | | | see [Text](/typography/text) |
-| tag | string | no | `h1` | `[h1, h2, h3, h4, h5, h6]` |
-| color | string | no | `textBase` | |
-| lineHeight | number or string | no | `2` | |
+| as | string | no | `h1` | `[h1, h2, h3, h4, h5, h6]` |
+| `COMMON` | Style Prop |  |  | see [Style Props](/style-props) |
+| `TYPOGRAPHY` | Style Prop |  |  | see [Style Props](/style-props) |
+| `LAYOUT` | Style Prop |  |  | see [Style Props](/style-props) |
+| `MISC` | Style Prop |  |  | see [Style Props](/system-props) |
 
 
 ## Theming

--- a/packages/core/components/heading/index.mdx
+++ b/packages/core/components/heading/index.mdx
@@ -48,7 +48,7 @@ Use the `as` prop to change from the default `h1` element to `h2`, `h3`, `h4`, `
 | `COMMON` | Style Prop |  |  | see [Style Props](/style-props) |
 | `TYPOGRAPHY` | Style Prop |  |  | see [Style Props](/style-props) |
 | `LAYOUT` | Style Prop |  |  | see [Style Props](/style-props) |
-| `MISC` | Style Prop |  |  | see [Style Props](/system-props) |
+| `MISC` | Style Prop |  |  | see [Style Props](/style-props) |
 
 
 ## Theming
@@ -78,4 +78,4 @@ Use the `as` prop to change from the default `h1` element to `h2`, `h3`, `h4`, `
 ```
 
 - [Default theme](https://github.com/raster-foundry/blasterjs/tree/master/packages/core/theme/components/heading)
-- [Learn more about themeing](#)
+- [Learn more about themeing]()

--- a/packages/core/constants.js
+++ b/packages/core/constants.js
@@ -1,8 +1,23 @@
 import * as ss from "styled-system";
 
+const textShadow = ss.style({
+  prop: "textShadow",
+  cssProperty: "textShadow"
+});
+
+const textOverflow = ss.style({
+  prop: "textOverflow",
+  cssProperty: "textOverflow"
+});
+
+const textDecoration = ss.style({
+  prop: "textDecoration",
+  cssProperty: "textDecoration"
+});
+
 export const composer = ss.compose;
 
-export const COMMON = composer(ss.color, ss.space);
+export const COMMON = composer(ss.color, ss.display, ss.space);
 
 export const BORDER = composer(ss.borders, ss.borderColor, ss.borderRadius);
 
@@ -16,6 +31,9 @@ export const BACKGROUND = composer(
 );
 
 export const TYPOGRAPHY = composer(
+  textDecoration,
+  textOverflow,
+  textShadow,
   ss.fontFamily,
   ss.fontSize,
   ss.fontStyle,
@@ -26,7 +44,6 @@ export const TYPOGRAPHY = composer(
 );
 
 export const LAYOUT = composer(
-  ss.display,
   ss.size,
   ss.width,
   ss.height,

--- a/packages/core/theme/base.js
+++ b/packages/core/theme/base.js
@@ -87,10 +87,10 @@ export const shadows = [
   `0px 2px 5px -2px ${colors.gray900}33`,
   `0px 2px 5px 0px ${colors.gray900}33`,
   `0px 2px 10px 1px ${colors.gray900}20`,
-  `0px 12px 20px -3px ${colors.gray900}20, 
-    0px 2px 20px -9px ${colors.gray900}20`,
-  `0 12px 17px 2px ${colors.gray900}20,
-    0 5px 22px 4px ${colors.gray900}20`
+  `0px 12px 20px -3px ${colors.gray900}20, 0px 2px 20px -9px ${
+    colors.gray900
+  }20`,
+  `0 12px 17px 2px ${colors.gray900}20, 0 5px 22px 4px ${colors.gray900}20`
 ];
 
 export const space = [

--- a/packages/core/theme/components/breadcrumbs/index.js
+++ b/packages/core/theme/components/breadcrumbs/index.js
@@ -3,7 +3,7 @@ export const theme = {
     p: 1
   },
   colors: {
-    color: "gray3",
+    color: "gray500",
     colorHover: "primary",
     colorSeparator: "gray200",
     colorHighlight: "gray800"


### PR DESCRIPTION
## Overview
As part of our crusade to stop utilizing `Box` and `Text` on every component.

- `Heading` component no longer extends `Text`
- `Heading` utilizes Styled Props from `constants.js`
- New documentation pages
  - Style Props `/style-props`
  - Blaster Theme `/blaster-theme`
- Moved `Blaster` into Primitives menu

### Checklist

- [x] Relevant documentation pages have been created or updated
- [x] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


Are there any of the following in this PR?

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

### Notes

There may be updates to docs or components that utilize Heading


## Testing Instructions

 * Ensure Heading works as before
 * Checkout `/style-props`
 * Checkout `/blaster-theme`
 * Make sure `Blaster` component docs exists at `/primitives/blaster`
