### PR TITLE
v1 button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Major Button component overhaul
 
 ## [0.0.20] - 2019-05-01
 ### Changed
@@ -57,7 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [#100](https://github.com/raster-foundry/blasterjs/pull/111)
 - CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [#120](https://github.com/raster-foundry/blasterjs/pull/120)
 
-[unreleased]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.20...HEAD
+[Unreleased]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.20...HEAD
 [0.0.20]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.19...v0.0.20
 [0.0.19]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/:raster-foundry/blasterjs/compare/v0.0.17...v0.0.18

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -1,11 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { darken, rgba } from "polished";
+import { darken, rgba, getLuminance, shade } from "polished";
 import styled, { css, keyframes } from "styled-components";
 import { borders, borderColor, borderRadius, themeGet } from "styled-system";
-import Text from "../text";
+import {
+  COMMON,
+  BACKGROUND,
+  BORDER,
+  TYPOGRAPHY,
+  MISC,
+  LAYOUT,
+  POSITION
+} from "../../constants";
 import Icon from "../icon";
-import { Appearance, Intent } from "../../index.common";
 
 const ButtonIcon = styled(Icon)`
   flex: none;
@@ -20,18 +27,6 @@ const ButtonChildren = styled.span`
       opacity: 0;
       pointer-events: none;
       user-select: none;
-    `};
-
-  ${props =>
-    !props.iconBefore &&
-    css`
-      margin-left: ${themeGet("space.1", "0.8rem")};
-    `};
-
-  ${props =>
-    !props.iconAfter &&
-    css`
-      margin-right: ${themeGet("space.1", "0.8rem")};
     `};
 `;
 
@@ -58,7 +53,7 @@ const ButtonLoading = styled.span`
   }
 `;
 
-const StyledButton = styled(Text)`
+const StyledButton = styled.button`
   position: relative;
   cursor: pointer;
   display: inline-flex;
@@ -66,66 +61,113 @@ const StyledButton = styled(Text)`
   justify-content: center;
   align-items: center;
   outline: 0;
-  line-height: 1.1;
   text-align: center;
-  text-decoration: none;
   user-select: none;
   will-change: box-shadow, background-color;
   transition: 0.1s ease-in-out, box-shadow, 0.1s ease-in-out background-color;
-  font-weight: 600;
-  min-height: 36px;
-  ${borders}
-  ${borderColor}
-  ${borderRadius}
-
+  text-decoration: ${props => (!props.textDecoration ? "none" : "")};
+  font-family: ${props =>
+    !props.fontFamily ? themeGet("button.base.fonts.font", "fonts.body") : ""};
+  
   ${props => buttonStates(props)}
+  ${props => buttonScaling(props)}
+
+  ${props =>
+    props.block &&
+    css`
+      display: block;
+      width: 100%;
+    `}
+
+  ${themeGet("button.styles")};
+  ${COMMON}
+  ${BACKGROUND}
+  ${BORDER}
+  ${TYPOGRAPHY}
+  ${MISC}
+  ${LAYOUT}
+  ${POSITION}
 `;
+
+function buttonScaling(props) {
+  return css`
+    padding-top: ${themeGet(
+      `button.scale.${props.scale}.space.pt`,
+      `button.base.space.pt`
+    )};
+    padding-bottom: ${themeGet(
+      `button.scale.${props.scale}.space.pb`,
+      `button.base.space.pb`
+    )};
+    padding-left: ${themeGet(
+      `button.scale.${props.scale}.space.pl`,
+      `button.base.space.pl`
+    )};
+    padding-right: ${themeGet(
+      `button.scale.${props.scale}.space.pr`,
+      `button.base.space.pr`
+    )};
+    border-radius: ${themeGet(
+      `button.scale.${props.scale}.radii.radius`,
+      `button.base.radii.radius`
+    )};
+    font-size: ${themeGet(
+      `button.scale.${props.scale}.fontSizes.fontSize`,
+      `button.base.fontSizes.fontSize`
+    )};
+    font-weight: ${themeGet(
+      `button.scale.${props.scale}.fontWeights.fontWeight`,
+      `button.base.fontWeights.fontWeight`
+    )};
+    line-height: ${themeGet(
+      `button.scale.${props.scale}.lineHeights.lineHeight`,
+      `button.base.lineHeights.lineHeight`
+    )};
+  `;
+}
 
 function buttonStates(props) {
   const { intent, appearance } = props;
 
-  let color;
-  switch (intent) {
-    case Intent.DANGER:
-      color = "danger";
-      break;
-    case Intent.WARNING:
-      color = "warning";
-      break;
-    case Intent.SUCCESS:
-      color = "success";
-      break;
-    case Intent.NONE:
-    default:
-      color = "primary";
-      break;
-  }
-
   let fg, bg, border, bgHover, fgDisabled, bgDisabled;
 
   switch (appearance) {
-    case Appearance.PROMINENT:
-      fg = themeGet("colors.white", "#000")(props);
-      bg = themeGet(`colors.${color}`)(props);
-      border = `none`;
-      bgHover = themeGet(`colors.${color}Shade`)(props);
+    case "prominent":
+      bg = themeGet(
+        `button.intents.colors.${props.intent}`,
+        `button.intents.colors.default`
+      )(props);
+      fg =
+        getLuminance(bg) >= "0.5"
+          ? themeGet(`button.base.colors.darkText`)(props)
+          : themeGet(`button.base.colors.lightText`)(props);
+      border = `1px solid ${bg}`;
+      bgHover = shade(0.1, bg);
       fgDisabled = rgba(fg, 0.6);
       bgDisabled = rgba(bg, 0.5);
       break;
-    case Appearance.MINIMAL:
-      fg = themeGet(`colors.${color}`)(props);
+    case "minimal":
+      fg = themeGet(
+        `button.intents.colors.${props.intent}`,
+        `button.intents.colors.default`
+      )(props);
       bg = "transparent";
-      border = "none";
-      bgHover = themeGet("colors.gray100", "#e0e5f5")(props);
+      border = "1px solid transparent";
+      bgHover = rgba("#fff", 0.1);
       fgDisabled = rgba(fg, 0.6);
       bgDisabled = "transparent";
       break;
-    case Appearance.DEFAULT:
+    case "default":
     default:
-      fg = themeGet(`colors.${color}`)(props);
-      bg = themeGet("colors.gray100", "#e0e5f5")(props);
-      border = `1px solid ${darken(0.03, bg)}`;
-      bgHover = darken(0.02, bg);
+      bg = themeGet(`button.base.colors.defaultBg`)(props);
+      fg = themeGet(
+        `button.intents.colors.${props.intent}`,
+        `button.intents.colors.default`
+      )(props);
+      border = `1px solid ${themeGet(`button.base.colors.defaultBorder`)(
+        props
+      )};`;
+      bgHover = themeGet(`button.base.hover.colors.defaultBg`)(props);
       fgDisabled = rgba(fg, 0.6);
       bgDisabled = rgba(bg, 0.5);
       break;
@@ -162,15 +204,9 @@ function buttonStates(props) {
       props.disabled &&
       css`
         cursor: not-allowed;
+        user-select: none;
         background-color: ${bgDisabled};
         color: ${fgDisabled};
-      `}
-
-    ${props =>
-      props.block &&
-      css`
-        display: block;
-        width: 100%;
       `}
   `;
 }
@@ -197,31 +233,27 @@ const Button = ({ iconBefore, iconAfter, isLoading, children, ...props }) => {
 };
 
 Button.propTypes = {
-  ...Text.propTypes,
-  ...borders.propTypes,
-  ...borderColor.propTypes,
-  ...borderRadius.propTypes,
-  color: PropTypes.string,
-  intent: PropTypes.oneOf(Object.values(Intent)),
-  appearance: PropTypes.oneOf(Object.values(Appearance)),
+  ...COMMON.propTypes,
+  ...BACKGROUND.propTypes,
+  ...BORDER.propTypes,
+  ...TYPOGRAPHY.propTypes,
+  ...MISC.propTypes,
+  ...LAYOUT.propTypes,
+  ...POSITION.propTypes,
+  appearance: PropTypes.oneOf(["default", "prominent", "minimal"]),
+  intent: PropTypes.string,
+  scale: PropTypes.string,
+  iconBefore: PropTypes.string,
+  iconAfter: PropTypes.string,
   block: PropTypes.bool,
   disabled: PropTypes.bool,
-  iconBefore: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  iconAfter: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  isLoading: PropTypes.bool,
-  isActive: PropTypes.bool
+  isLoading: PropTypes.bool
 };
 
 Button.defaultProps = {
-  tag: "button",
-  pt: "button.p",
-  pb: "button.p",
-  pl: "button.p",
-  pr: "button.p",
-  border: 0,
-  borderRadius: "button.borderRadius",
-  intent: Intent.NONE,
-  appearance: Appearance.DEFAULT,
+  as: "button",
+  intent: "default",
+  appearance: "default",
   block: false,
   disabled: false,
   iconBefore: undefined,

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { darken, rgba, getLuminance, shade } from "polished";
 import styled, { css, keyframes } from "styled-components";
-import { borders, borderColor, borderRadius, themeGet } from "styled-system";
+import { themeGet } from "styled-system";
 import {
   COMMON,
   BACKGROUND,

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -153,7 +153,7 @@ function buttonStates(props) {
       )(props);
       bg = "transparent";
       border = "1px solid transparent";
-      bgHover = rgba("#fff", 0.1);
+      bgHover = themeGet(`colors.gray100`)(props);
       fgDisabled = rgba(fg, 0.6);
       bgDisabled = "transparent";
       break;
@@ -207,6 +207,13 @@ function buttonStates(props) {
         user-select: none;
         background-color: ${bgDisabled};
         color: ${fgDisabled};
+      `}
+      
+    ${props =>
+      props.disabled &&
+      props.appearance === "prominent" &&
+      css`
+        border-color: transparent;
       `}
   `;
 }

--- a/packages/core/components/button/index.mdx
+++ b/packages/core/components/button/index.mdx
@@ -6,71 +6,41 @@ route: /components/button
 
 import { Playground, Props } from 'docz'
 import Button from './'
-import { Intent } from "../../common/intent";
-import { Appearance } from "../../common/appearance";
 
 # Button
 
-## Basic usage
+## Import
+`import { Button } from '@blasterjs/core'`
+
+## Basic Usage
+
+The `<Button>` component renders a `<button>` with basic styles by default.
+
 <Playground>
   <Button>Button</Button>
-</Playground>
-
-## Appearance
-<Playground>
-  <Button appearance={Appearance.MINIMAL}>Minimal Button</Button>
-  <Button appearance={Appearance.DEFAULT}>Default Button</Button>
-  <Button appearance={Appearance.PROMINENT}>Prominent Button</Button>
-</Playground>
-
-## Intent
-<Playground>
-  <Button intent={Intent.NONE} appearance={Appearance.MINIMAL}>None</Button>
-  <Button intent={Intent.SUCCESS} appearance={Appearance.MINIMAL}>Success</Button>
-  <Button intent={Intent.WARNING} appearance={Appearance.MINIMAL}>Warning</Button>
-  <Button intent={Intent.DANGER} appearance={Appearance.MINIMAL}>Danger</Button>
-  <br /><br />
-  <Button intent={Intent.NONE} appearance={Appearance.DEFAULT}>None</Button>
-  <Button intent={Intent.SUCCESS} appearance={Appearance.DEFAULT}>Success</Button>
-  <Button intent={Intent.WARNING} appearance={Appearance.DEFAULT}>Warning</Button>
-  <Button intent={Intent.DANGER} appearance={Appearance.DEFAULT}>Danger</Button>
-  <br /><br />
-  <Button intent={Intent.NONE} appearance={Appearance.PROMINENT}>None</Button>
-  <Button intent={Intent.SUCCESS} appearance={Appearance.PROMINENT}>Success</Button>
-  <Button intent={Intent.WARNING} appearance={Appearance.PROMINENT}>Warning</Button>
-  <Button intent={Intent.DANGER} appearance={Appearance.PROMINENT}>Danger</Button>
+  <Button appearance="minimal">Button</Button>
+  <Button appearance="prominent" intent="success">Button</Button>
 </Playground>
 
 ## Icons
 <Playground>
-  <Button iconBefore="edit" appearance={Appearance.MINIMAL} intent={Intent.NONE}>Before</Button>
-  <Button iconBefore="edit" appearance={Appearance.MINIMAL} intent={Intent.SUCCESS}>Before</Button>
-  <Button iconBefore="edit" appearance={Appearance.MINIMAL} intent={Intent.WARNING}>Before</Button>
-  <Button iconBefore="edit" appearance={Appearance.MINIMAL} intent={Intent.DANGER}>Before</Button>
-  <br /><br />
-  <Button iconAfter="eye" intent={Intent.NONE}>After</Button>
-  <Button iconAfter="eye" intent={Intent.SUCCESS}>After</Button>
-  <Button iconAfter="eye" intent={Intent.WARNING}>After</Button>
-  <Button iconAfter="eye" intent={Intent.DANGER}>After</Button>
-  <br /><br />
-  <Button iconBefore="minus" iconAfter="plus" appearance={Appearance.PROMINENT} intent={Intent.NONE}>Both</Button>
-  <Button iconBefore="minus" iconAfter="plus" appearance={Appearance.PROMINENT} intent={Intent.SUCCESS}>Both</Button>
-  <Button iconBefore="minus" iconAfter="plus" appearance={Appearance.PROMINENT} intent={Intent.WARNING}>Both</Button>
-  <Button iconBefore="minus" iconAfter="plus" appearance={Appearance.PROMINENT} intent={Intent.DANGER}>Both</Button>
+  <Button iconAfter="eye" intent="default">After</Button>
+  <Button iconBefore="edit" appearance="minimal" intent="primary">Before</Button>
+  <Button iconBefore="minus" iconAfter="plus" appearance="prominent" intent="default">Both</Button>
 </Playground>
 
 ## Disabled
 <Playground>
-  <Button disabled appearance={Appearance.MINIMAL}>Minimal</Button>
-  <Button disabled appearance={Appearance.DEFAULT}>Default</Button>
-  <Button disabled appearance={Appearance.PROMINENT}>Prominent</Button>
+  <Button disabled appearance="minimal">Minimal</Button>
+  <Button disabled appearance="default">Default</Button>
+  <Button disabled appearance="prominent">Prominent</Button>
 </Playground>
 
 ## Loading
 <Playground>
-  <Button isLoading appearance={Appearance.MINIMAL}>Minimal</Button>
-  <Button isLoading appearance={Appearance.DEFAULT}>Default</Button>
-  <Button isLoading appearance={Appearance.PROMINENT}>Prominent</Button>
+  <Button isLoading appearance="minimal">Minimal</Button>
+  <Button isLoading appearance="default">Default</Button>
+  <Button isLoading appearance="prominent">Prominent</Button>
 </Playground>
 
 ## Block
@@ -79,14 +49,127 @@ import { Appearance } from "../../common/appearance";
 </Playground>
 
 ### PropTypes
-| Prop | Type | Required | Default | Description |
-|:-----|:-----|:---------|:--------|:------------|
-| Text props | | | | see [Text](/typography/text) |
-| borderRadius | number or string | no | `base` | |
-| intent | enum | no | `NONE` | see [Intent](/common/intent) |
-| appearance | enum | no | `DEFAULT` | see [Appearance](/common/appearance) |
-| block | bool | no | | |
-| disabled | bool | no | | |
-| iconBefore | string | no | | |
-| iconAfter | string | no | | |
-| isLoading | bool | no | | |
+| Prop | Type | Required | Default | Description | Themeable |
+|:-----|:-----|:---------|:--------|:------------|:----------|
+| appearance | enum | no | `default` | `["default", "prominent", "minimal"]` |  |
+| intent | string | no | `default` | Theme provides styles for `["default", primary", "success", "warning", "danger"]` | yes |
+| scale | string | no | | Theme provides styles for `["small", "large"` | yes |
+| block | bool | no | `false` | Makes the button fill available space |
+| disabled | bool | no | `false` | Sets the `disabled` attribute on the Button |
+| isLoading | bool | no | `false` | Displays an animated loading icon in place of children |
+| iconBefore | bool | no | `false` | Displays an animated loading icon in place of children |
+| `COMMON` | Style Prop |  |  | see [Style Props](/style-props) |
+| `BACKGROUND` | Style Prop |  |  | see [Style Props](/style-props) |
+| `BORDER` | Style Prop |  |  | see [Style Props](/style-props) |
+| `TYPOGRAPHY` | Style Prop |  |  | see [Style Props](/style-props) |
+| `MISC` | Style Prop |  |  | see [Style Props](/style-props) |
+| `LAYOUT` | Style Prop |  |  | see [Style Props](/style-props) |
+| `POSITION` | Style Prop |  |  | see [Style Props](/style-props) |
+
+
+## Theming
+
+### Schema
+```
+{
+  base: {
+    colors: {
+      defaultBg,
+      defaultBorder,
+      darkText,
+      lightText
+    },
+    space: {
+      pt,
+      pb,
+      pl,
+      pr
+    },
+    radii: {
+      radius
+    },
+    fonts: {
+      font
+    },
+    fontSizes: {
+      fontSize
+    },
+    fontWeights: {
+      fontWeight
+    },
+    lineHeights: {
+      lineHeight
+    },
+    hover: {
+      colors: {
+        defaultBg,
+        defaultBorder,
+        darkText,
+        lightText
+      }
+    }
+  },
+  intents: {
+    colors: {
+      default,
+      secondary,
+      primary,
+      success,
+      warning,
+      danger,
+      $CUSTOM_KEY
+    }
+  },
+  scale: {
+    small: {
+      space: {
+        pt,
+        pb,
+        pl,
+        pr
+      },
+      radii: {
+        radius
+      },
+      fontSizes: {
+        fontSize
+      },
+      fontWeights: {
+        fontWeight
+      },
+      lineHeights: {
+        lineHeight
+      }
+    },
+    large: {
+      space: {
+        pt,
+        pb,
+        pl,
+        pr
+      },
+      radii: {
+        radius
+      },
+      fontSizes: {
+        fontSize
+      },
+      fontWeights: {
+        fontWeight
+      },
+      lineHeights: {
+        lineHeight
+      }
+    },
+    $CUSTOM_KEY: {
+      ...
+    }
+  },
+  styles: css`
+    ...
+  `
+}
+```
+
+- [Default theme](https://github.com/raster-foundry/blasterjs/tree/master/packages/core/theme/components/heading)
+- [Learn more about themeing]()

--- a/packages/core/theme/base.js
+++ b/packages/core/theme/base.js
@@ -21,17 +21,17 @@ export const colors = {
   offWhite: "#F4F5F7",
   black: "#000000",
 
-  green: "#91C66A",
-  greenTint: "#C4E8A9",
-  greenShade: "#5B833E",
+  green: "#51BF56",
+  greenTint: "#C7EAC9",
+  greenShade: "#2D7B31",
 
-  red: "#E0535F",
-  redTint: "#F8B2B8",
-  redShade: "#941D27",
+  red: "#D42C3A",
+  redTint: "#F2C0C4",
+  redShade: "#A9232E",
 
-  yellow: "#ECBC40",
-  yellowTint: "#FFE9AF",
-  yellowShade: "#C19523"
+  yellow: "#DCA209",
+  yellowTint: "#FCE8B6",
+  yellowShade: "#AB7E07"
 };
 
 {
@@ -110,8 +110,8 @@ export const space = [
 export const lineHeights = {
   inherit: "inherit",
   small: "1",
-  base: "1.5",
-  large: "1.8"
+  base: "1.3",
+  large: "1.6"
 };
 
 export const fontWeights = {};

--- a/packages/core/theme/components/button/index.js
+++ b/packages/core/theme/components/button/index.js
@@ -1,8 +1,94 @@
+import { css } from "styled-components";
+
 export const theme = {
-  space: {
-    p: 1
+  base: {
+    colors: {
+      defaultBg: "white",
+      defaultBorder: "gray300",
+      darkText: "gray800",
+      lightText: "white"
+    },
+    space: {
+      pt: 1,
+      pb: 1,
+      pl: 2,
+      pr: 2
+    },
+    radii: {
+      radius: "base"
+    },
+    fonts: {
+      font: "body"
+    },
+    fontSizes: {
+      fontSize: 2
+    },
+    fontWeights: {
+      fontWeight: 600
+    },
+    lineHeights: {
+      lineHeight: "base"
+    },
+    hover: {
+      colors: {
+        defaultBg: "gray100",
+        defaultBorder: "gray300",
+        darkText: "gray800",
+        lightText: "white"
+      }
+    }
   },
-  radii: {
-    borderRadius: "base"
-  }
+  intents: {
+    colors: {
+      default: "gray700",
+      secondary: "secondary",
+      primary: "primary",
+      success: "success",
+      warning: "warning",
+      danger: "danger"
+    }
+  },
+  scale: {
+    small: {
+      space: {
+        pt: 1,
+        pb: 1,
+        pl: 1,
+        pr: 1
+      },
+      radii: {
+        radius: "small"
+      },
+      fontSizes: {
+        fontSize: 1
+      },
+      fontWeights: {
+        fontWeight: 600
+      },
+      lineHeights: {
+        lineHeight: "base"
+      }
+    },
+    large: {
+      space: {
+        pt: 2,
+        pb: 2,
+        pl: 2,
+        pr: 2
+      },
+      radii: {
+        radius: "large"
+      },
+      fontSizes: {
+        fontSize: 3
+      },
+      fontWeights: {
+        fontWeight: 600
+      },
+      lineHeights: {
+        lineHeight: "base"
+      }
+    }
+  },
+  styles: css``
 };


### PR DESCRIPTION
## Overview
- Rewrites a majority of the Button theme logic to work with updated base theme logic.
- `Button` no longer extends `Text`
- `Button` no longer relies on enum files `appearance` or `intent`. This functionality has moved into the theme to allow for greater flexibility with overrides.
- All styled-system style props now override correctly.
- Prop updates:
  - Removes `tag` prop in favor of `as`
  - Removes `isActive`
  - Adds `scale` prop
  - `iconBefore`, `iconAfter` now only accept strings
  - styled-system props all updated to constants
- slight adjustments to base theme included

### Checklist

- [x] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible


Are there any of the following in this PR?


- [x] Changes to the prop names or types of existing components
- [x] Changes in intended behavior of existing component props
- [x] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project


If one of the above is checked...

- [ ] information or guidance around needed changes for consumers of this library has been added to the changelog under `Upgrade Instructions`

Closes #152
