### PR TITLE
Add FocusVisible component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,27 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
 ### Changed
+
 - Button theme structure changed
 - Dialog custom transitions, overlay color, opacity. Props and theme structure changed.
 
 ### Added
+
 - RangeInput component
+- FocusVisible component
 
 ## [1.0.0-alpha.5] - 2019-07-29 [YANKED]
 
 ## [1.0.0-alpha.4] - 2019-07-25
+
 ### Changed
+
 - Major Icon component overhaul
 - Updated Card to compositional theme system. Removed density prop.
 - Updated Text to compositional theme system.
@@ -32,18 +39,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.0.0-alpha.1] - 2019-06-12 [YANKED]
 
 ## [1.0.0-alpha.0] - 2019-06-03
+
 ### Changed
+
 - Major Button component overhaul
 - Major Badge component overhaul
 
 ## [0.0.20] - 2019-05-01
+
 ### Changed
+
 - Renamed `Header` to `Heading`
 - Updated Heading to utilize Styled Props
 - Moved Blaster component docs to Primitives menu
 - Updated A component to utilize Styled Props
 
 ### Added
+
 - new documentation for Blaster Theme and Styled Props
 
 ## [0.0.19] - 2019-04-19
@@ -51,7 +63,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.0.18] - 2019-04-19
 
 ## [0.0.17] - 2019-04-19
+
 ### Added
+
 - Added Blaster application wrapper component [#173](https://github.com/raster-foundry/blasterjs/pull/173)
 
 ## [0.0.16] - 2019-03-20
@@ -59,11 +73,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.0.15] - 2019-03-20
 
 ## [0.0.14] - 2019-03-11
+
 ### Added
+
 - Added chan for changelog management
 
 ## 0.0.14-alpha.1 - 2019-03-11
+
 ### Added
+
 - `Divider` component added to the core package [#94](https://github.com/raster-foundry/blasterjs/pull/94)
 - `Icon` component added to the core package [#103](https://github.com/raster-foundry/blasterjs/pull/103)
 - `Box` component added to the core package [#112](https://github.com/raster-foundry/blasterjs/pull/112)
@@ -76,15 +94,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Table` components added to the core package [#132](https://github.com/raster-foundry/blasterjs/pull/132)
 
 ### Changed
+
 - Changed theme file `radius` to `radii` (breaking change for custom themes)
 - Normalized usage of styled-system across every component
 - Renamed `Link` to `A`.
 - Refactored theme system to support per-component themeing, replacing `defaultTheme.js` with a `theme` folder [#129](https://github.com/raster-foundry/blasterjs/pull/129)
 
 ### Removed
+
 - Removed reset.css.
 
 ### Fixed
+
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [#100](https://github.com/raster-foundry/blasterjs/pull/111)
 - CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [#120](https://github.com/raster-foundry/blasterjs/pull/120)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12137,6 +12137,11 @@
 			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
 			"dev": true
 		},
+		"focus-visible": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.0.2.tgz",
+			"integrity": "sha512-zT2fj/bmOgEBjqGbURGlowTmCwsIs3bRDMr/sFZz8Ly7VkEiwuCn9swNTL3pPuf8Oua2de7CLuKdnuNajWdDsQ=="
+		},
 		"follow-redirects": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
   },
   "bin": {
     "blaster": "./bin/cli.js"
+  },
+  "dependencies": {
+    "focus-visible": "^5.0.2"
   }
 }

--- a/packages/core/components/a/index.js
+++ b/packages/core/components/a/index.js
@@ -8,7 +8,11 @@ const A = styled.a`
   color: ${themeGet("a.colors.color")};
   font-weight: ${themeGet("a.fontWeights.fontWeight")};
 
-  &:focus {
+  &:focus-visible {
+    color: ${props =>
+      themeGet(`colors.${props.colorFocus}`, "a.colors.colorFocus")};
+  }
+  .js-focus-visible &.focus-visible {
     color: ${props =>
       themeGet(`colors.${props.colorFocus}`, "a.colors.colorFocus")};
   }

--- a/packages/core/components/blaster/index.js
+++ b/packages/core/components/blaster/index.js
@@ -3,11 +3,13 @@ import { ThemeProvider } from "styled-components";
 
 import { getTheme } from "../../theme";
 import GlobalStyle from "../globalStyle";
+import FocusVisible from "../focusVisible";
 
 export default ({ children, theme }) => (
   <ThemeProvider theme={getTheme(theme)}>
     <>
       <GlobalStyle />
+      <FocusVisible />
       {children}
     </>
   </ThemeProvider>

--- a/packages/core/components/brand/index.js
+++ b/packages/core/components/brand/index.js
@@ -22,7 +22,11 @@ const StyledBrand = styled.a`
   font-size: ${themeGet("brand.fontSizes.fontSize")};
   font-weight: ${themeGet("brand.fontWeights.fontWeight")};
 
-  &:focus {
+  &:focus-visible {
+    color: ${props =>
+      themeGet(`colors.${props.colorFocus}`, "brand.colors.colorFocus")};
+  }
+  .js-focus-visible &.focus-visible {
     color: ${props =>
       themeGet(`colors.${props.colorFocus}`, "brand.colors.colorFocus")};
   }

--- a/packages/core/components/breadcrumbs/index.js
+++ b/packages/core/components/breadcrumbs/index.js
@@ -73,7 +73,17 @@ const BreadcrumbItem = styled.a`
           `};
   }
 
-  &:focus {
+  &:focus-visible {
+    ${props =>
+      props.colorFocus
+        ? css`
+            color: ${themeGet(`colors.${props.colorFocus}`, props.colorFocus)};
+          `
+        : css`
+            color: ${themeGet("breadcrumbs.colors.colorFocus")};
+          `};
+  }
+  .js-focus-visible &.focus-visible {
     ${props =>
       props.colorFocus
         ? css`

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -184,7 +184,11 @@ function buttonStates(props) {
           background-color: ${darken(0.02, bgHover)};
         }
 
-        &:focus {
+        &:focus-visible {
+          outline: none;
+          box-shadow: 0 0 0 4px ${rgba(themeGet("colors.primary")(props), 0.3)};
+        }
+        .js-focus-visible &.focus-visible {
           outline: none;
           box-shadow: 0 0 0 4px ${rgba(themeGet("colors.primary")(props), 0.3)};
         }

--- a/packages/core/components/checkbox/index.js
+++ b/packages/core/components/checkbox/index.js
@@ -4,6 +4,7 @@ import styled, { css } from "styled-components";
 import { themeGet } from "styled-system";
 import Icon from "../icon";
 import { COMMON, FLEX_ITEM, LAYOUT, MISC, POSITION } from "../../constants";
+import { blurUnlessFocusVisible } from "../../utils";
 
 const StyledCheckbox = styled.span`
   position: relative;
@@ -116,6 +117,7 @@ const Checkbox = ({
         name={name}
         value={value}
         onChange={e => onChange(e, e.target.value)}
+        onFocus={e => blurUnlessFocusVisible(e.target)}
         disabled={disabled}
         defaultChecked={defaultChecked}
         checked={indeterminate || checked}

--- a/packages/core/components/focusVisible/index.js
+++ b/packages/core/components/focusVisible/index.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { createGlobalStyle } from "styled-components";
+import { themeGet } from "styled-system";
+import 'focus-visible';
+
+const FocusVisible = createGlobalStyle`
+    /*
+      Hide focus indicator if element receives focus via mouse,
+      but show if focused via keyboard.
+    */
+    .js-focus-visible :focus:not(.focus-visible) {
+        outline: none;
+    }
+
+    /* Custom keyboard focus style */
+    *:focus-visible {
+        ${themeGet("focusVisible.styles")}
+    }
+    .js-focus-visible .focus-visible {
+        ${themeGet("focusVisible.styles")}
+    }
+`;
+
+export default FocusVisible;

--- a/packages/core/components/radio/index.js
+++ b/packages/core/components/radio/index.js
@@ -4,6 +4,7 @@ import styled, { css } from "styled-components";
 import { themeGet } from "styled-system";
 import Icon from "../icon";
 import { COMMON, FLEX_ITEM, LAYOUT, MISC, POSITION } from "../../constants";
+import { blurUnlessFocusVisible } from "../../utils";
 
 const StyledRadio = styled.span`
   position: relative;
@@ -99,6 +100,7 @@ const Radio = ({
         name={name}
         value={value}
         onChange={e => onChange(e, e.target.value)}
+        onFocus={e => blurUnlessFocusVisible(e.target)}
         disabled={disabled}
         defaultChecked={defaultChecked}
         checked={checked}

--- a/packages/core/components/select/index.js
+++ b/packages/core/components/select/index.js
@@ -90,6 +90,9 @@ const SelectSelect = styled.select`
 `;
 
 const Select = ({
+  value,
+  defaultValue,
+  onChange,
   multiple,
   required,
   disabled,
@@ -111,6 +114,9 @@ const Select = ({
   return (
     <StyledSelect disabled={disabled} invalid={invalid} {...props}>
       <SelectSelect
+        value={value}
+        defaultValue={defaultValue}
+        onChange={e => onChange(e, e.target.value)}
         multiple={multiple}
         required={required}
         disabled={disabled}
@@ -143,12 +149,18 @@ Select.propTypes = {
   ...LAYOUT.propTypes,
   ...POSITION.propTypes,
   ...FLEX_ITEM.propTypes,
+  value: PropTypes.string,
+  defaultValue: PropTypes.string,
+  onChange: PropTypes.func,
   icon: PropTypes.string,
   iconColor: PropTypes.string
 };
 
 Select.defaultProps = {
-  icon: "caretDown"
+  icon: "caretDown",
+  value: undefined,
+  defaultValue: undefined,
+  onChange: () => {},
 };
 
 export default Select;

--- a/packages/core/index.components.js
+++ b/packages/core/index.components.js
@@ -13,6 +13,7 @@ export { default as Dialog } from "./components/dialog";
 export { default as Divider } from "./components/divider";
 export { default as Field } from "./components/field";
 export { default as FileInput } from "./components/fileInput";
+export { default as FocusVisible } from "./components/focusVisible";
 export { default as GlobalStyle } from "./components/globalStyle";
 export { default as Grouper } from "./components/grouper";
 export { default as Heading } from "./components/heading";

--- a/packages/core/theme/components/focusVisible/index.js
+++ b/packages/core/theme/components/focusVisible/index.js
@@ -1,0 +1,5 @@
+import { css } from "styled-components";
+
+export const theme = {
+    styles: css``
+};

--- a/packages/core/theme/components/index.js
+++ b/packages/core/theme/components/index.js
@@ -12,6 +12,7 @@ export { theme as dialog } from "./dialog";
 export { theme as divider } from "./divider";
 export { theme as field } from "./field";
 export { theme as fileInput } from "./fileInput";
+export { theme as focusVisible } from "./focusVisible";
 export { theme as grouper } from "./grouper";
 export { theme as heading } from "./heading";
 export { theme as icon } from "./icon";

--- a/packages/core/utils.js
+++ b/packages/core/utils.js
@@ -42,3 +42,9 @@ export const replaceThemeRefs = (o, theme) => {
       }
     });
 };
+
+export const blurUnlessFocusVisible = el => {
+  if (Element.prototype.matches && !el.matches('.focus-visible')) {
+    el.blur()
+  }
+};


### PR DESCRIPTION
## Overview

Uses [WICG's focus-visible library](https://github.com/WICG/focus-visible) to suppress focus treatments on elements focused via mouse. Focus treatment is retained when focused via keyboard.

The library is wrapped in a new `<FocusVisible>` component that should be included as a child of the `<Blaster>` component when this functionality is preferred (which should be most cases).

Default focus treatment can be customized in `FocusVisible`'s theme file.

Existing components that have a `:focus` treatment have been updated to use the `.js-focus-visible &.focus-visible` and `:focus-visible` selectors instead of `:focus`.

Since `<Checkbox>` and `<Radio>` are rendered artificially, with their underlying input elements made invisible, their focus treatments have been styled via `:focus-within` instead of `:focus`. However, there is currently no way to mimic something like `:focus-visible-within`. So we use a hack :( to blur the underlying `<input>` element immediately on focus by mouse (not kb), so the `:focus-within` treatment doesn't appear. This hack does not affect functionality in practice, though it's semantically incorrect.

`<Select>` is also rendered artificially, but the `blurUnlessFocusVisible()` solution above won't work across browsers. So for now `<Select>` is the exception and will render its focus treatment even on mouse focus.

### Checklist

- [ ] Relevant documentation pages have been created or updated
- [x] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible
- [ ] Relevant status has been updated on the status page

### Upgrade instructions

If there are any of the following in this PR, provide proper instructions on how to upgrade:

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

### Notes

Encountered and fixed a bug where `<Select>` wasn't passing critical form props (`value`, `defaultValue`, `onChange`) to the underlying `<select>` element.

## Testing Instructions

- Compare focus treatment – or lack thereof – when focusing on various components via keyboard vs mouse: `A`, `Brand`, `Breadcrumbs`, `Button`, `Checkbox`, `Radio`, `Select`.
- Customize default focus treatment in the `FocusVisible` theme file and test that.

Closes #207 
