### PR TITLE
Make Select work with Label via `htmlFor` and `id` props

### DIFF
--- a/packages/core/components/label/index.mdx
+++ b/packages/core/components/label/index.mdx
@@ -6,6 +6,7 @@ route: /form/label
 
 import { Playground, Props } from 'docz'
 import Label from './'
+import Select from '../select/'
 
 # Label
 
@@ -21,6 +22,14 @@ import Label from './'
     </Label>
 </Playground>
 
+<Playground>
+    <Label htmlFor="swallow">What do you mean?</Label>
+    <Select id="swallow">
+        <option>African</option>
+        <option>European</option>
+    </Select>
+</Playground>
+
 
 ## PropTypes
 
@@ -29,6 +38,7 @@ import Label from './'
 | `COMMON` | Style Prop |  |  | see [Style Props](/style-props) |
 | `TYPOGRAPHY` | Style Prop |  |  | see [Style Props](/style-props) |
 | `FLEX_ITEM` | Style Prop |  |  | see [Style Props](/style-props) |
+| htmlFor | string | no | | passed down to nested `label` element |
 
 
 ## Theming

--- a/packages/core/components/select/index.js
+++ b/packages/core/components/select/index.js
@@ -90,6 +90,7 @@ const SelectSelect = styled.select`
 `;
 
 const Select = ({
+  id,
   value,
   defaultValue,
   onChange,
@@ -114,6 +115,7 @@ const Select = ({
   return (
     <StyledSelect disabled={disabled} invalid={invalid} {...props}>
       <SelectSelect
+        id={id}
         value={value}
         defaultValue={defaultValue}
         onChange={e => onChange(e, e.target.value)}
@@ -149,6 +151,7 @@ Select.propTypes = {
   ...LAYOUT.propTypes,
   ...POSITION.propTypes,
   ...FLEX_ITEM.propTypes,
+  id: PropTypes.string,
   value: PropTypes.string,
   defaultValue: PropTypes.string,
   onChange: PropTypes.func,


### PR DESCRIPTION
## Overview

Ensure `<Select>` passes `id` prop down to nested `<select>` element.

Document use of `htmlFor` prop with `<Label>`.

### Checklist

- [x] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible
- [ ] Relevant status has been updated on the status page

### Upgrade instructions

If there are any of the following in this PR, provide proper instructions on how to upgrade:

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

## Testing Instructions

- Examine second example on `<Label>` docs page. Ensure clicking the label focuses on the associated `<select>` element.

Closes #225.
Closes #226.
