### PR TITLE
Add `whiteSpace` prop to styled-system TYPOGRAPHY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+## Added
+- Added custom styled-system `whiteSpace` prop to the TYPOGRAPHY prop group
 
 ## [1.0.0-alpha.7] - 2019-09-06 [YANKED]
 

--- a/packages/core/components/text/index.mdx
+++ b/packages/core/components/text/index.mdx
@@ -16,7 +16,7 @@ import Text from './'
 
 Exposes text based props: `color`, `fontFamily`, `fontSize`, `fontWeight`,
 `fontStyle`, `textAlign`, `lineHeight`, `letterSpacing`, `textDecoration`,
-`textOverflow`, `textShadow`, `textTransform`.
+`textOverflow`, `textShadow`, `textTransform`, `whiteSpace`.
 
 The `<Text>` component renders a `<span>` with basic styles by default.
 

--- a/packages/core/constants.js
+++ b/packages/core/constants.js
@@ -20,6 +20,11 @@ const textTransform = ss.style({
   cssProperty: "textTransform"
 });
 
+const whiteSpace = ss.style({
+  prop: "whiteSpace",
+  cssProperty: "whiteSpace"
+});
+
 export const composer = ss.compose;
 
 export const COMMON = composer(ss.color, ss.display, ss.space);
@@ -40,6 +45,7 @@ export const TYPOGRAPHY = composer(
   textOverflow,
   textShadow,
   textTransform,
+  whiteSpace,
   ss.fontFamily,
   ss.fontSize,
   ss.fontStyle,


### PR DESCRIPTION
## Overview

Adds a custom styled-system property to handle the css `white-space` property.

### Checklist

- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible
