### PR TITLE
Make Text element inherit font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,41 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Text component now inherits font-size [#235](https://github.com/raster-foundry/blasterjs/pull/235)
+
 ## [1.0.0-alpha.8] - 2019-09-13
+
 ### Added
+
 - Added custom styled-system `whiteSpace` prop to the TYPOGRAPHY prop group
 
-## [1.0.0-alpha.7] - 2019-09-06 [YANKED]
+## [1.0.0-alpha.7] - 2019-09-06
 
 ## [1.0.0-alpha.6] - 2019-09-06
+
 ### Changed
+
 - Button theme structure changed
 - Dialog custom transitions, overlay color, opacity. Props and theme structure changed.
 
 ### Added
+
 - RangeInput component
 - FocusVisible component
 
-## [1.0.0-alpha.5] - 2019-07-29 [YANKED]
+## [1.0.0-alpha.5] - 2019-07-29
 
-## [1.0.0-alpha.4] - 2019-07-25
+## 1.0.0-alpha.4 - 2019-07-25
+
 ### Changed
+
 - Major Icon component overhaul
 - Updated Card to compositional theme system. Removed density prop.
 - Updated Text to compositional theme system.
@@ -34,45 +46,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated ProgressBar to compositional theme system.
 - Updated Swatch to compositional theme system. Replaced shape prop with rounded and circle props.
 
-## [1.0.0-alpha.3] - 2019-07-02 [YANKED]
+## 1.0.0-alpha.3 - 2019-07-02
 
-## [1.0.0-alpha.2] - 2019-06-20 [YANKED]
+## 1.0.0-alpha.2 - 2019-06-20
 
-## [1.0.0-alpha.1] - 2019-06-12 [YANKED]
+## 1.0.0-alpha.1 - 2019-06-12
 
-## [1.0.0-alpha.0] - 2019-06-03
+## 1.0.0-alpha.0 - 2019-06-03
+
 ### Changed
+
 - Major Button component overhaul
 - Major Badge component overhaul
 
-## [0.0.20] - 2019-05-01
+## 0.0.20 - 2019-05-01
+
 ### Changed
+
 - Renamed `Header` to `Heading`
 - Updated Heading to utilize Styled Props
 - Moved Blaster component docs to Primitives menu
 - Updated A component to utilize Styled Props
 
 ### Added
+
 - new documentation for Blaster Theme and Styled Props
 
-## [0.0.19] - 2019-04-19
+## 0.0.19 - 2019-04-19
 
-## [0.0.18] - 2019-04-19
+## 0.0.18 - 2019-04-19
 
-## [0.0.17] - 2019-04-19
+## 0.0.17 - 2019-04-19
+
 ### Added
+
 - Added Blaster application wrapper component [#173](https://github.com/raster-foundry/blasterjs/pull/173)
 
-## [0.0.16] - 2019-03-20
+## 0.0.16 - 2019-03-20
 
-## [0.0.15] - 2019-03-20
+## 0.0.15 - 2019-03-20
 
-## [0.0.14] - 2019-03-11
+## 0.0.14 - 2019-03-11
+
 ### Added
+
 - Added chan for changelog management
 
 ## 0.0.14-alpha.1 - 2019-03-11
+
 ### Added
+
 - `Divider` component added to the core package [#94](https://github.com/raster-foundry/blasterjs/pull/94)
 - `Icon` component added to the core package [#103](https://github.com/raster-foundry/blasterjs/pull/103)
 - `Box` component added to the core package [#112](https://github.com/raster-foundry/blasterjs/pull/112)
@@ -85,15 +108,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Table` components added to the core package [#132](https://github.com/raster-foundry/blasterjs/pull/132)
 
 ### Changed
+
 - Changed theme file `radius` to `radii` (breaking change for custom themes)
 - Normalized usage of styled-system across every component
 - Renamed `Link` to `A`.
 - Refactored theme system to support per-component themeing, replacing `defaultTheme.js` with a `theme` folder [#129](https://github.com/raster-foundry/blasterjs/pull/129)
 
 ### Removed
+
 - Removed reset.css.
 
 ### Fixed
+
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [#100](https://github.com/raster-foundry/blasterjs/pull/111)
 - CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [#120](https://github.com/raster-foundry/blasterjs/pull/120)
 

--- a/packages/core/components/text/index.js
+++ b/packages/core/components/text/index.js
@@ -35,7 +35,7 @@ const Text = styled.span`
   }
 
   font-family: ${themeGet("text.fonts.fontFamily")};
-  font-size: ${themeGet("text.fontSizes.fontSize")};
+  font-size: inherit;
   line-height: ${themeGet("text.lineHeights.lineHeight")};
 
   ${themeGet("text.styles")}

--- a/packages/core/components/text/index.mdx
+++ b/packages/core/components/text/index.mdx
@@ -58,6 +58,8 @@ The `<Text>` component renders a `<span>` with basic styles by default.
   <Text color="primary">Primary color</Text>
   <br />
   <Text textAlign="center" fontSize="12px" as="p">Small and centered</Text>
+  <br />
+  <Text fontSize={4}>Large and in <Text fontWeight="bold">another Text element</Text></Text>
 </Playground>
 
 ## PropTypes
@@ -76,9 +78,6 @@ The `<Text>` component renders a `<span>` with basic styles by default.
 {
   fonts: {
     fontFamily
-  },
-  fontSizes: {
-    fontSize
   },
   lineHeights: {
     lineHeight


### PR DESCRIPTION
## Overview

This PR makes `Text` components inherit font-size which allows for more predictable usage. I think it makes sense since that is how `span`s work and since the `GlobalStyle` component makes the font size for `body` themeable.

### Checklist

- [x] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible
- [-] Relevant status has been updated on the status page

## Testing Instructions

- See new doc example in action

Closes #234 
