### PR TITLE
Use polished normalize in GlobalStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- GlobalStyle component now uses normalize() from polished
 
 ## [1.0.0] - 2020-01-08
 ### Changed
@@ -115,7 +117,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Build script for docz documentation site and it now properly copies the reset.css file into the dist folder [#100](https://github.com/raster-foundry/blasterjs/pull/111)
 - CLI method `files` now properly filters by provided extension and now only `.js` files are used to generate the `index.common.js` file for each package [#120](https://github.com/raster-foundry/blasterjs/pull/120)
 
-[unreleased]: https://github.com/:raster-foundry/blasterjs/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/:raster-foundry/blasterjs/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/:raster-foundry/blasterjs/compare/v1.0.0-beta.0...v1.0.0
 [1.0.0-beta.0]: https://github.com/:raster-foundry/blasterjs/compare/v1.0.0-alpha.8...v1.0.0-beta.0
 [1.0.0-alpha.8]: https://github.com/:raster-foundry/blasterjs/compare/v1.0.0-alpha.7...v1.0.0-alpha.8

--- a/packages/core/components/globalStyle/index.js
+++ b/packages/core/components/globalStyle/index.js
@@ -1,60 +1,10 @@
 import React from "react";
 import { createGlobalStyle } from "styled-components";
 import { themeGet } from "styled-system";
+import { normalize } from "polished";
 
 const GlobalStyle = createGlobalStyle`
-    div, span, applet, object, iframe,
-    h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-    a, abbr, acronym, address, big, cite, code,
-    del, dfn, em, img, ins, kbd, q, s, samp,
-    small, strike, strong, sub, sup, tt, var,
-    b, u, i, center,
-    dl, dt, dd, ol, ul, li,
-    fieldset, form, label, legend,
-    table, caption, tbody, tfoot, thead, tr, th, td,
-    article, aside, canvas, details, embed,
-    figure, figcaption, footer, header, hgroup,
-    menu, nav, output, ruby, section, summary,
-    time, mark, audio, video {
-        margin: 0;
-        padding: 0;
-        border: 0;
-        font-size: 100%;
-        font: inherit;
-        vertical-align: baseline;
-    }
-    /* HTML5 display-role reset for older browsers */
-    article, aside, details, figcaption, figure,
-    footer, header, hgroup, menu, nav, section {
-        display: block;
-    }
-    body,
-    html {
-        margin: 0;
-        padding: 0;
-        border: 0;
-        vertical-align: baseline;
-    }
-    ol, ul {
-        list-style: none;
-    }
-    blockquote, q {
-        quotes: none;
-    }
-    blockquote:before, blockquote:after,
-    q:before, q:after {
-        content: '';
-        content: none;
-    }
-    table {
-        border-collapse: collapse;
-        border-spacing: 0;
-    }
-    *,
-    *:after,
-    *:before {
-        box-sizing: border-box;
-    }
+   ${normalize()}
     html {
         font-size: 62.5%;
     }


### PR DESCRIPTION
## Overview

This PR removes _most_ of the original global styles which were derived from normalize.css and instead uses the `normalize()` method from polished.

It maintains the themeable rules and also keeps the body font-size rule for the 1rem => 10px equivalence.

### Checklist

- [x] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible

### Upgrade instructions

This PR shouldn't require any upgrades.

## Testing Instructions

- Check out the docs and see that everything looks the same as before

Closes #242 
