### PR TITLE
Fix link to Lerna commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ asymmetric or symmetric shortcuts.
 | `npm run release`   | Create a new release interactively with Lerna                                                                                             |
 | `npm run clean`     | Remove all existing `node_modules` directories                                                                                            |
 
-All Lerna [Lerna commands](https://lernajs.io/) are also available.
+All [Lerna commands](https://lerna.js.org/#commands) are also available.
 
 ### Package Structure
 


### PR DESCRIPTION
## Overview

The lernajs.io domain no longer connects to the project documentation.

We have updated the link to jump directly to the commands listing in the
documentation since that is the context in which the link is presented.

More information about the project domain change available in this PR
https://github.com/lerna/lerna/issues/2033#issuecomment-483812533

### Checklist

- [ ] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible
- [ ] Relevant status has been updated on the status page

### Upgrade instructions

If there are any of the following in this PR, provide proper instructions on how to upgrade:

- [ ] Changes to the prop names or types of existing components
- [ ] Changes in intended behavior of existing component props
- [ ] Changes in the theme file's structure
- [ ] A required version bump to a non-dev dependency of the project

## Testing Instructions

- Verify that the link to the Lerna documentation works
