### PR TITLE
Use key "overrides" instead of "styles" in theme

### DIFF
--- a/packages/core/components/a/index.js
+++ b/packages/core/components/a/index.js
@@ -27,7 +27,7 @@ const A = styled.a`
       themeGet(`colors.${props.colorActive}`, "a.colors.colorActive")};
   }
 
-  ${themeGet("a.styles")}
+  ${themeGet("a.overrides")}
   ${COMMON}
   ${TYPOGRAPHY}
   ${FLEX_ITEM}

--- a/packages/core/components/a/index.mdx
+++ b/packages/core/components/a/index.mdx
@@ -47,7 +47,7 @@ Accepts standard html `<a>` attributes
   fontWeights: {
     fontWeight
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/badge/index.js
+++ b/packages/core/components/badge/index.js
@@ -27,7 +27,7 @@ const Badge = styled.span`
   ${props => badgeAppearance(props)}
   ${props => badgeScaling(props)}
 
-  ${themeGet("badge.styles")};
+  ${themeGet("badge.overrides")};
   ${COMMON}
   ${BACKGROUND}
   ${BORDER}

--- a/packages/core/components/badge/index.mdx
+++ b/packages/core/components/badge/index.mdx
@@ -149,7 +149,7 @@ The `<Badge>` component renders a `<span>` with basic styles by default. It's co
       ...
     }
   },
-  styles: css``
+  overrides: css``
 }
 ```
 

--- a/packages/core/components/brand/index.js
+++ b/packages/core/components/brand/index.js
@@ -41,7 +41,7 @@ const StyledBrand = styled.a`
       themeGet(`colors.${props.colorActive}`, "brand.colors.colorActive")};
   }
 
-  ${themeGet("brand.styles")}
+  ${themeGet("brand.overrides")}
   ${COMMON}
   ${LAYOUT}
   ${POSITION}

--- a/packages/core/components/brand/index.mdx
+++ b/packages/core/components/brand/index.mdx
@@ -71,7 +71,7 @@ import Brand from './'
   fontWeights: {
     fontWeight
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/breadcrumbs/index.js
+++ b/packages/core/components/breadcrumbs/index.js
@@ -43,7 +43,7 @@ const StyledBreadcrumbs = styled.div`
       }
     `}
 
-  ${themeGet("breadcrumbs.styles")}
+  ${themeGet("breadcrumbs.overrides")}
   ${COMMON}
   ${LAYOUT}
   ${TYPOGRAPHY}

--- a/packages/core/components/breadcrumbs/index.mdx
+++ b/packages/core/components/breadcrumbs/index.mdx
@@ -81,7 +81,7 @@ Future versions should integrate with React Router.
   fontSizes: {
     fontSize
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/button/index.js
+++ b/packages/core/components/button/index.js
@@ -74,7 +74,7 @@ const StyledButton = styled.button`
       width: 100%;
     `}
 
-  ${themeGet("button.styles")};
+  ${themeGet("button.overrides")};
   ${COMMON}
   ${BACKGROUND}
   ${BORDER}

--- a/packages/core/components/button/index.mdx
+++ b/packages/core/components/button/index.mdx
@@ -159,7 +159,7 @@ The `<Button>` component renders a `<button>` with basic styles by default.
       ...
     }
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/callout/index.js
+++ b/packages/core/components/callout/index.js
@@ -42,7 +42,7 @@ const StyledCallout = styled.div`
       padding-left: 0;
   `};
 
-  ${themeGet("callout.styles")}
+  ${themeGet("callout.overrides")}
   ${STYLED}
 `;
 

--- a/packages/core/components/callout/index.mdx
+++ b/packages/core/components/callout/index.mdx
@@ -118,7 +118,7 @@ import Text from '../text/'
       danger
     }
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/card/index.js
+++ b/packages/core/components/card/index.js
@@ -15,7 +15,7 @@ const Card = styled.div`
   border-radius: ${themeGet("card.radii.borderRadius")};
   box-shadow: ${themeGet("card.shadows.boxShadow")};
 
-  ${themeGet("card.styles")}
+  ${themeGet("card.overrides")}
   ${STYLED}
 `;
 

--- a/packages/core/components/card/index.mdx
+++ b/packages/core/components/card/index.mdx
@@ -81,7 +81,7 @@ import { Heading, Text, Button } from "../../"
   borders: {
     border
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/checkbox/index.js
+++ b/packages/core/components/checkbox/index.js
@@ -51,7 +51,7 @@ const StyledCheckbox = styled.span`
     }
   }
 
-  ${themeGet("checkbox.styles")}
+  ${themeGet("checkbox.overrides")}
   ${COMMON}
   ${FLEX_ITEM}
   ${LAYOUT}

--- a/packages/core/components/checkbox/index.mdx
+++ b/packages/core/components/checkbox/index.mdx
@@ -87,7 +87,7 @@ For uncontrolled, you must omit the `checked` prop.  And optionally supply the
     indeterminateColor,
     shadowColorFocus
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/colorInput/index.js
+++ b/packages/core/components/colorInput/index.js
@@ -11,7 +11,7 @@ const ColorInput = styled.input`
   border: ${themeGet("colorInput.borders.border")};
   border-radius: ${themeGet("colorInput.radii.borderRadius")};
 
-  ${themeGet("colorInput.styles")}
+  ${themeGet("colorInput.overrides")}
   ${COMMON}
   ${BORDER}
   ${LAYOUT}

--- a/packages/core/components/colorInput/index.mdx
+++ b/packages/core/components/colorInput/index.mdx
@@ -43,7 +43,7 @@ import ColorInput from './'
   radii: {
     borderRadius
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/dialog/index.js
+++ b/packages/core/components/dialog/index.js
@@ -36,7 +36,7 @@ const StyledDialog = styled.div`
   background-color: ${themeGet("dialog.colors.bg")};
   box-shadow: ${themeGet("dialog.shadows.boxShadow")};
 
-  ${themeGet("dialog.styles")}
+  ${themeGet("dialog.overrides")}
   ${COMMON}
   ${BORDER}
   ${MISC}

--- a/packages/core/components/dialog/index.mdx
+++ b/packages/core/components/dialog/index.mdx
@@ -159,7 +159,7 @@ and function defaults to `ease-in-out`.
       beforeClose: css``
     },
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/divider/index.js
+++ b/packages/core/components/divider/index.js
@@ -11,7 +11,7 @@ const HDivider = styled.hr`
   width: ${themeGet("divider.widths.horizontal")};
   height: ${themeGet("divider.heights.horizontal")};
 
-  ${themeGet("divider.styles.horizontal")};
+  ${themeGet("divider.overrides.horizontal")};
 
   ${COMMON}
   ${LAYOUT}
@@ -33,7 +33,7 @@ const VDivider = styled.span`
   width: ${themeGet("divider.widths.vertical")};
   height: ${themeGet("divider.heights.vertical")};
 
-  ${themeGet("divider.styles.vertical")};
+  ${themeGet("divider.overrides.vertical")};
 
   ${COMMON}
   ${LAYOUT}

--- a/packages/core/components/divider/index.mdx
+++ b/packages/core/components/divider/index.mdx
@@ -75,7 +75,7 @@ Use the `vertical` prop to render a `span` as a vertical divider.
     horizontal,
     vertical,
   },
-  styles: {
+  overrides: {
     horizontal: css`
         ...
     `,

--- a/packages/core/components/fileInput/index.js
+++ b/packages/core/components/fileInput/index.js
@@ -12,7 +12,7 @@ const FileInput = styled.input`
   background-color: ${themeGet("fileInput.colors.bg")};
   color: ${themeGet("fileInput.colors.color")};
 
-  ${themeGet("fileInput.styles")}
+  ${themeGet("fileInput.overrides")}
   ${COMMON}
   ${BORDER}
   ${LAYOUT}

--- a/packages/core/components/fileInput/index.mdx
+++ b/packages/core/components/fileInput/index.mdx
@@ -47,7 +47,7 @@ import FileInput from './'
   radii: {
     borderRadius
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/focusVisible/index.js
+++ b/packages/core/components/focusVisible/index.js
@@ -14,10 +14,10 @@ const FocusVisible = createGlobalStyle`
 
     /* Custom keyboard focus style */
     *:focus-visible {
-        ${themeGet("focusVisible.styles")}
+        ${themeGet("focusVisible.overrides")}
     }
     .js-focus-visible .focus-visible {
-        ${themeGet("focusVisible.styles")}
+        ${themeGet("focusVisible.overrides")}
     }
 `;
 

--- a/packages/core/components/grouper/index.js
+++ b/packages/core/components/grouper/index.js
@@ -5,7 +5,7 @@ import { themeGet } from "styled-system";
 import { COMMON, LAYOUT } from "../../constants";
 
 const OuterGrouper = styled.div`
-  ${themeGet("grouper.styles")}
+  ${themeGet("grouper.overrides")}
   ${COMMON}
   ${LAYOUT}
 `;

--- a/packages/core/components/grouper/index.mdx
+++ b/packages/core/components/grouper/index.mdx
@@ -125,7 +125,7 @@ Renders a horizontal or vertical group of items.
   space: {
     gutter
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/heading/index.js
+++ b/packages/core/components/heading/index.js
@@ -12,7 +12,7 @@ const Heading = styled.h1`
   margin-top: ${themeGet("heading.space.mt")};
   font-size: ${props => themeGet(`heading.fontSizes.${props.as}`)};
 
-  ${themeGet("heading.styles")}
+  ${themeGet("heading.overrides")}
   ${COMMON}
   ${LAYOUT}
   ${POSITION}

--- a/packages/core/components/heading/index.mdx
+++ b/packages/core/components/heading/index.mdx
@@ -78,7 +78,7 @@ Use the `as` prop to change from the default `h1` element to `h2`, `h3`, `h4`, `
   lineHeights: {
     lineHeight
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/icon/index.js
+++ b/packages/core/components/icon/index.js
@@ -16,7 +16,7 @@ const StyledIcon = styled.svg`
       height: 1em;
     `}
 
-  ${themeGet("icon.styles")};
+  ${themeGet("icon.overrides")};
   ${COMMON}
   ${FLEX_ITEM}
   ${LAYOUT}

--- a/packages/core/components/icon/index.mdx
+++ b/packages/core/components/icon/index.mdx
@@ -51,7 +51,7 @@ Note that you can pass standard [svg attributes](https://developer.mozilla.org/e
 ### Schema
 ```
 icon: {
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/image/index.js
+++ b/packages/core/components/image/index.js
@@ -25,7 +25,7 @@ const Image = styled.img`
     }
   }}
 
-  ${themeGet("image.styles")}
+  ${themeGet("image.overrides")}
   ${COMMON}
   ${BORDER}
   ${LAYOUT}

--- a/packages/core/components/image/index.mdx
+++ b/packages/core/components/image/index.mdx
@@ -64,7 +64,7 @@ Accepts standard html `<img>` attributes
   radii: {
     rounded
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/label/index.js
+++ b/packages/core/components/label/index.js
@@ -6,7 +6,7 @@ import { COMMON, TYPOGRAPHY, FLEX_ITEM } from "../../constants";
 const Label = styled.label`
   font-size: ${themeGet('label.fontSizes.fontSize')};
 
-  ${themeGet("label.styles")}
+  ${themeGet("label.overrides")}
   ${COMMON}
   ${TYPOGRAPHY}
   ${FLEX_ITEM}

--- a/packages/core/components/label/index.mdx
+++ b/packages/core/components/label/index.mdx
@@ -49,7 +49,7 @@ import Select from '../select/'
   fontSizes: {
     fontSize
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/pagination/index.js
+++ b/packages/core/components/pagination/index.js
@@ -22,7 +22,7 @@ const StyledPagination = styled.nav`
 
   font-size: ${themeGet('pagination.fontSizes.fontSize')};
 
-  ${themeGet("pagination.styles")};
+  ${themeGet("pagination.overrides")};
   ${COMMON}
   ${BACKGROUND}
   ${TYPOGRAPHY}

--- a/packages/core/components/pagination/index.mdx
+++ b/packages/core/components/pagination/index.mdx
@@ -94,7 +94,7 @@ import Pagination from './'
   fontSizes: {
     fontSize
   },
-  styles: css``
+  overrides: css``
 }
 ```
 

--- a/packages/core/components/progressBar/index.js
+++ b/packages/core/components/progressBar/index.js
@@ -55,7 +55,7 @@ const ProgressBar = styled.div`
       `;
     }}
 
-    ${themeGet("progressBar.styles.topBar")};
+    ${themeGet("progressBar.overrides.topBar")};
   }
 
   height: ${themeGet("progressBar.heights.height")};
@@ -63,7 +63,7 @@ const ProgressBar = styled.div`
   background-color: ${themeGet("progressBar.colors.bg")};
   color: ${themeGet("progressBar.colors.color")};
 
-  ${themeGet("progressBar.styles.backBar")};
+  ${themeGet("progressBar.overrides.backBar")};
   ${COMMON}
   ${BORDER}
   ${LAYOUT}

--- a/packages/core/components/progressBar/index.mdx
+++ b/packages/core/components/progressBar/index.mdx
@@ -80,7 +80,7 @@ Use the `striped` and `animated` prop to change the default appearance and show 
   heights: {
     height
   },
-  styles: {
+  overrides: {
     backBar: css``,
     topBar: css``
   }

--- a/packages/core/components/radio/index.js
+++ b/packages/core/components/radio/index.js
@@ -44,7 +44,7 @@ const StyledRadio = styled.span`
     }
   }
 
-  ${themeGet("radio.styles")}
+  ${themeGet("radio.overrides")}
   ${COMMON}
   ${FLEX_ITEM}
   ${LAYOUT}

--- a/packages/core/components/radio/index.mdx
+++ b/packages/core/components/radio/index.mdx
@@ -84,7 +84,7 @@ For uncontrolled, you must omit the `checked` prop.  And optionally supply the
     uncheckedColor,
     shadowColorFocus
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/rangeInput/index.js
+++ b/packages/core/components/rangeInput/index.js
@@ -140,7 +140,7 @@ const StyledRangeInput = styled.input`
     cursor: not-allowed;
   }
 
-  ${themeGet("rangeInput.styles")};
+  ${themeGet("rangeInput.overrides")};
   ${COMMON}
   ${POSITION}
   ${FLEX_ITEM}

--- a/packages/core/components/rangeInput/index.mdx
+++ b/packages/core/components/rangeInput/index.mdx
@@ -85,7 +85,7 @@ For uncontrolled, you must omit the `value` prop. And optionally supply the
     thumb,
     track
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/select/index.js
+++ b/packages/core/components/select/index.js
@@ -58,7 +58,7 @@ const StyledSelect = styled.div`
     vertical-align: middle;
   }
 
-  ${themeGet("select.styles")};
+  ${themeGet("select.overrides")};
   ${COMMON}
   ${BACKGROUND}
   ${BORDER}

--- a/packages/core/components/select/index.mdx
+++ b/packages/core/components/select/index.mdx
@@ -94,7 +94,7 @@ For uncontrolled, you must omit the `value` prop. And optionally supply the
   radii: {
     borderRadius
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/swatch/index.js
+++ b/packages/core/components/swatch/index.js
@@ -28,7 +28,7 @@ const StyledSwatch = styled.span`
   height: ${themeGet("swatch.heights.height")};
   padding: ${themeGet("swatch.space.p")};
 
-  ${themeGet("swatch.styles")}
+  ${themeGet("swatch.overrides")}
   ${COMMON}
   ${BORDER}
   ${LAYOUT}

--- a/packages/core/components/swatch/index.mdx
+++ b/packages/core/components/swatch/index.mdx
@@ -53,7 +53,7 @@ import Swatch from '../swatch'
   radii: {
     rounded
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/table/index.js
+++ b/packages/core/components/table/index.js
@@ -94,7 +94,7 @@ const Table = styled.table`
     `
   }}
 
-  ${themeGet("table.styles")}
+  ${themeGet("table.overrides")}
   ${COMMON}
   ${BORDER}
   ${LAYOUT}

--- a/packages/core/components/table/index.mdx
+++ b/packages/core/components/table/index.mdx
@@ -124,7 +124,7 @@ styling (beyond setting `<th>` to bold).
   borderWidths: {
     borderWidth
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/text/index.js
+++ b/packages/core/components/text/index.js
@@ -38,7 +38,7 @@ const Text = styled.span`
   font-size: inherit;
   line-height: ${themeGet("text.lineHeights.lineHeight")};
 
-  ${themeGet("text.styles")}
+  ${themeGet("text.overrides")}
   ${COMMON}
   ${LAYOUT}
   ${POSITION}

--- a/packages/core/components/text/index.mdx
+++ b/packages/core/components/text/index.mdx
@@ -82,7 +82,7 @@ The `<Text>` component renders a `<span>` with basic styles by default.
   lineHeights: {
     lineHeight
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/textArea/index.js
+++ b/packages/core/components/textArea/index.js
@@ -47,7 +47,7 @@ const StyledTextArea = styled.textarea`
     background-color: ${themeGet("textArea.colors.bgInvalid")};
   }
 
-  ${themeGet("textArea.styles")};
+  ${themeGet("textArea.overrides")};
   ${COMMON}
   ${BACKGROUND}
   ${BORDER}

--- a/packages/core/components/textArea/index.mdx
+++ b/packages/core/components/textArea/index.mdx
@@ -66,7 +66,7 @@ import TextArea from './'
   radii: {
     borderRadius
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/textInput/index.js
+++ b/packages/core/components/textInput/index.js
@@ -45,7 +45,7 @@ const StyledTextInput = styled.input`
     background-color: ${themeGet("textInput.colors.bgInvalid")};
   }
 
-  ${themeGet("textInput.styles")};
+  ${themeGet("textInput.overrides")};
   ${COMMON}
   ${BACKGROUND}
   ${BORDER}

--- a/packages/core/components/textInput/index.mdx
+++ b/packages/core/components/textInput/index.mdx
@@ -90,7 +90,7 @@ For uncontrolled, you must omit the `value` prop. And optionally supply the
   radii: {
     borderRadius
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/components/tooltip/index.js
+++ b/packages/core/components/tooltip/index.js
@@ -23,7 +23,7 @@ const TooltipContent = styled.span`
   font-size: ${themeGet("tooltip.fontSizes.fontSize")};
   box-shadow: ${themeGet("tooltip.shadows.boxShadow")};
 
-  ${themeGet("tooltip.styles")}
+  ${themeGet("tooltip.overrides")}
   ${COMMON}
   ${BORDER}
   ${TYPOGRAPHY}

--- a/packages/core/components/tooltip/index.mdx
+++ b/packages/core/components/tooltip/index.mdx
@@ -113,7 +113,7 @@ const Foo = ({children, ...props}) => {
   fontSizes: {
     fontSize
   },
-  styles: css`
+  overrides: css`
     ...
   `
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blasterjs/core",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/theme/base.js
+++ b/packages/core/theme/base.js
@@ -126,5 +126,5 @@ export const borders = {};
 export const borderWidths = {};
 export const borderStyles = {};
 export const zIndices = {};
-export const styles = {};
+export const overrides = {};
 export { default as icons } from "./icons";

--- a/packages/core/theme/components/a/index.js
+++ b/packages/core/theme/components/a/index.js
@@ -10,5 +10,5 @@ export const theme = {
   fontWeights: {
     fontWeight: "600"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/badge/index.js
+++ b/packages/core/theme/components/badge/index.js
@@ -80,5 +80,5 @@ export const theme = {
       }
     }
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/brand/index.js
+++ b/packages/core/theme/components/brand/index.js
@@ -16,5 +16,5 @@ export const theme = {
   fontWeights: {
     fontWeight: 600
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/breadcrumbs/index.js
+++ b/packages/core/theme/components/breadcrumbs/index.js
@@ -16,5 +16,5 @@ export const theme = {
   fontSizes: {
     fontSize: 2
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/button/index.js
+++ b/packages/core/theme/components/button/index.js
@@ -83,5 +83,5 @@ export const theme = {
       }
     }
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/callout/index.js
+++ b/packages/core/theme/components/callout/index.js
@@ -27,5 +27,5 @@ export const theme = {
       danger: "danger"
     }
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/card/index.js
+++ b/packages/core/theme/components/card/index.js
@@ -20,5 +20,5 @@ export const theme = {
   borders: {
     border: "1px solid"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/checkbox/index.js
+++ b/packages/core/theme/components/checkbox/index.js
@@ -7,5 +7,5 @@ export const theme = {
     indeterminateColor: "primary",
     shadowColorFocus: "primary"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/colorInput/index.js
+++ b/packages/core/theme/components/colorInput/index.js
@@ -10,5 +10,5 @@ export const theme = {
   radii: {
     borderRadius: 0
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/dialog/index.js
+++ b/packages/core/theme/components/dialog/index.js
@@ -59,5 +59,5 @@ export const theme = {
       `
     }
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/divider/index.js
+++ b/packages/core/theme/components/divider/index.js
@@ -13,7 +13,7 @@ export const theme = {
     horizontal: "1px",
     vertical: "100%"
   },
-  styles: {
+  overrides: {
     horizontal: css``,
     vertical: css``
   }

--- a/packages/core/theme/components/fileInput/index.js
+++ b/packages/core/theme/components/fileInput/index.js
@@ -14,5 +14,5 @@ export const theme = {
   radii: {
     borderRadius: 0
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/focusVisible/index.js
+++ b/packages/core/theme/components/focusVisible/index.js
@@ -1,5 +1,5 @@
 import { css } from "styled-components";
 
 export const theme = {
-    styles: css``
+    overrides: css``
 };

--- a/packages/core/theme/components/grouper/index.js
+++ b/packages/core/theme/components/grouper/index.js
@@ -4,5 +4,5 @@ export const theme = {
   space: {
     gutter: 1
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/heading/index.js
+++ b/packages/core/theme/components/heading/index.js
@@ -24,5 +24,5 @@ export const theme = {
   lineHeights: {
     lineHeight: "1.8"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/icon/index.js
+++ b/packages/core/theme/components/icon/index.js
@@ -1,5 +1,5 @@
 import { css } from "styled-components";
 
 export const theme = {
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/image/index.js
+++ b/packages/core/theme/components/image/index.js
@@ -4,5 +4,5 @@ export const theme = {
     radii: {
         rounded: "base"
     },
-    styles: css``
+    overrides: css``
 };

--- a/packages/core/theme/components/label/index.js
+++ b/packages/core/theme/components/label/index.js
@@ -4,5 +4,5 @@ export const theme = {
     fontSizes: {
         fontSize: 2
     },
-    styles: css``
+    overrides: css``
 };

--- a/packages/core/theme/components/pagination/index.js
+++ b/packages/core/theme/components/pagination/index.js
@@ -4,5 +4,5 @@ export const theme = {
     fontSizes: {
         fontSize: 2
     },
-    styles: css``
+    overrides: css``
 };

--- a/packages/core/theme/components/progressBar/index.js
+++ b/packages/core/theme/components/progressBar/index.js
@@ -11,7 +11,7 @@ export const theme = {
   heights: {
     height: "8px"
   },
-  styles: {
+  overrides: {
     backBar: css``,
     topBar: css``
   }

--- a/packages/core/theme/components/radio/index.js
+++ b/packages/core/theme/components/radio/index.js
@@ -6,5 +6,5 @@ export const theme = {
     uncheckedColor: "gray100",
     shadowColorFocus: "primary"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/rangeInput/index.js
+++ b/packages/core/theme/components/rangeInput/index.js
@@ -28,5 +28,5 @@ export const theme = {
     thumb: "none",
     track: "none"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/select/index.js
+++ b/packages/core/theme/components/select/index.js
@@ -29,5 +29,5 @@ export const theme = {
   radii: {
     borderRadius: 0
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/swatch/index.js
+++ b/packages/core/theme/components/swatch/index.js
@@ -13,5 +13,5 @@ export const theme = {
     radii: {
         rounded: "base"
     },
-    styles: css``
+    overrides: css``
 };

--- a/packages/core/theme/components/table/index.js
+++ b/packages/core/theme/components/table/index.js
@@ -13,5 +13,5 @@ export const theme = {
   borderWidths: {
     borderWidth: 1
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/text/index.js
+++ b/packages/core/theme/components/text/index.js
@@ -10,5 +10,5 @@ export const theme = {
   lineHeights: {
     lineHeight: "base"
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/textArea/index.js
+++ b/packages/core/theme/components/textArea/index.js
@@ -31,5 +31,5 @@ export const theme = {
   radii: {
     borderRadius: 0
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/textInput/index.js
+++ b/packages/core/theme/components/textInput/index.js
@@ -28,5 +28,5 @@ export const theme = {
   radii: {
     borderRadius: 0
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/theme/components/tooltip/index.js
+++ b/packages/core/theme/components/tooltip/index.js
@@ -18,5 +18,5 @@ export const theme = {
   fontSizes: {
     fontSize: 1
   },
-  styles: css``
+  overrides: css``
 };

--- a/packages/core/utils.js
+++ b/packages/core/utils.js
@@ -27,7 +27,7 @@ export const buildTheme = (base, components) => {
 export const replaceThemeRefs = (o, theme) => {
   const keys = Object.keys(o);
   keys
-    .filter(k => k !== "styles" && k !== "__filemeta" && !Array.isArray(o[k]))
+    .filter(k => k !== "overrides" && k !== "__filemeta" && !Array.isArray(o[k]))
     // For every entry in this level of the theme
     .forEach(k => {
       // check if there is a matching key in the base theme

--- a/packages/testbed/package-lock.json
+++ b/packages/testbed/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "testbed",
-	"version": "1.0.0-beta.0",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/theme-examples/basic-theme/components.js
+++ b/theme-examples/basic-theme/components.js
@@ -5,8 +5,8 @@ export default {
     {
       colors: {
         color: "red"
-      }
-      styles: css`
+      },
+      overrides: css`
         text-transform: uppercase;
       `
     }

--- a/theme-examples/basic-theme/index.js
+++ b/theme-examples/basic-theme/index.js
@@ -62,7 +62,7 @@ export default buildTheme(components, {
   zIndices: {
     // Base z-index overrides
   },
-  styles: {
+  overrides: {
     // Base style overrides
   }
 });


### PR DESCRIPTION
## Overview

In styled-components@5 `styles` became a magic string resulting in any style overrides to be absent from the theme provided to children of the `ThemeProvider` component. This PR changes the key of style overrides from `styles` to `overrides`.

### Checklist

- [x] Relevant documentation pages have been created or updated
- [ ] Description of PR is in an appropriate section of the changelog and grouped with similar changes if possible
- [NA] Relevant status has been updated on the status page

### Upgrade instructions

Consumer applications will need to update their theme files by renaming the style overrides -- the `styles` property (both at the top level of the theme file and at the component level) to `overrides`.

## Testing Instructions

TKTK

Closes #246 
